### PR TITLE
コンポーネント間での画面遷移ができるようにvuerouterを追加

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "sass": "^1.53.0",
-        "vue": "^3.2.37"
+        "vue": "^3.2.37",
+        "vue-router": "^4.1.2"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^3.0.0",
@@ -123,6 +124,11 @@
         "@vue/compiler-dom": "3.2.37",
         "@vue/shared": "3.2.37"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
+      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.2.37",
@@ -1499,6 +1505,20 @@
         "@vue/shared": "3.2.37"
       }
     },
+    "node_modules/vue-router": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1602,6 +1622,11 @@
         "@vue/compiler-dom": "3.2.37",
         "@vue/shared": "3.2.37"
       }
+    },
+    "@vue/devtools-api": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.2.1.tgz",
+      "integrity": "sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ=="
     },
     "@vue/reactivity": {
       "version": "3.2.37",
@@ -2430,6 +2455,14 @@
         "@vue/runtime-dom": "3.2.37",
         "@vue/server-renderer": "3.2.37",
         "@vue/shared": "3.2.37"
+      }
+    },
+    "vue-router": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
+      "requires": {
+        "@vue/devtools-api": "^6.1.4"
       }
     },
     "xtend": {

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "sass": "^1.53.0",
-    "vue": "^3.2.37"
+    "vue": "^3.2.37",
+    "vue-router": "^4.1.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^3.0.0",

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -1,9 +1,8 @@
 <script setup>
-  import HomePage from './components/pages/HomePage.vue'
 </script>
 
 <template>
-  <HomePage />
+  <router-view></router-view>
 </template>
 
 <style scoped>

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -1,7 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import VueRouter from './router'
 import './assets/styles/main.scss'
 import './assets/styles/reset.scss'
 import './assets/styles/tailwind.scss'
 
-createApp(App).mount('#app')
+createApp(App).use(VueRouter).mount('#app')

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -1,0 +1,29 @@
+import { createRouter, createWebHistory } from "vue-router";
+import HomePage from "../components/pages/HomePage.vue";
+import LoginPage from "../components/pages/LoginPage.vue";
+import SignUpPage from "../components/pages/SignUpPage.vue";
+
+const routes = [
+  {
+    path: "/home",
+    name: "Home",
+    component: HomePage,
+  },
+  {
+    path: "/signup",
+    name: "Singup",
+    component: SignUpPage,
+  },
+  {
+    path: "/login",
+    name: "Login",
+    component: LoginPage,
+  },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+export default router;


### PR DESCRIPTION
### 概要
SPAを作成するにあたりコンポーネント間での画面遷移をさせる必要があったのでvuerouterを使用してURLごとにページを切り替えられるようにした

### やったこと
- `npm install vue-router@4` 　_//  vue3対応_  
上記コマンドでインストール
- 設定ファイルを編集し、各URLでページが切り替わるように実装した

### 確認項目
- [x] URLごとに画面遷移できているか   
`/home` `/login` `/signup`
- [x] コンポーネントがURLごとに正しく表示されているか

close #10 