### PR TITLE
新規登録のフォームにバリデーションを実装

### DIFF
--- a/front/src/components/UsreForm/UserFormConfirm.vue
+++ b/front/src/components/UsreForm/UserFormConfirm.vue
@@ -1,16 +1,14 @@
 <template>
   <div class="md:flex md:items-center mb-6">
     <div class="md:w-1/3">
-      <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-password">
+      <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-confirm">
         パスワード確認
       </label>
     </div>
     <div class="md:w-2/3">
-      <input 
-        :value="userConfirm"
-        @input="$emit('update:userConfirm', $event.target.value)"
+      <input :value="userConfirm" @input="$emit('update:userConfirm', $event.target.value)"
         class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-500"
-        id="inline-password" type="password" placeholder="******************">
+        id="inline-confirm" type="password" placeholder="******************">
     </div>
   </div>
 </template>

--- a/front/src/components/UsreForm/UserFormEmail.vue
+++ b/front/src/components/UsreForm/UserFormEmail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="md:flex md:items-center mb-6">
     <div class="md:w-1/3">
-      <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-password">
+      <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-email">
         メールアドレス
       </label>
     </div>
@@ -10,7 +10,7 @@
         :value="userEmail" 
         @input="$emit('update:userEmail', $event.target.value)"
         class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-500"
-        id="inline-password" placeholder="workout@example.com">
+        id="inline-email" placeholder="workout@example.com">
     </div>
   </div>
 </template>

--- a/front/src/components/pages/SignUpPage.vue
+++ b/front/src/components/pages/SignUpPage.vue
@@ -16,8 +16,11 @@
         <div class="md:flex md:items-center">
           <div class="md:w-1/3"></div>
           <div class="md:w-2/3">
-            <button @click="registerDataSubmit"
-              class="shadow bg-blue-500 hover:bg-blue-400 duration-200 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
+            <button 
+              @click="clickSubmitButton" 
+              :disabled="disabled"
+              :class="{ 'bg-blue-300': disabled === true, 'bg-blue-500': disabled === false}"
+              class="shadow  focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
               type="button">
               新規会員登録
             </button>
@@ -43,6 +46,7 @@ export default  {
   },
   data() {
     return {
+      disabled: true,
       userName: '',
       userEmail: '',
       userPassword: '',
@@ -50,17 +54,64 @@ export default  {
     }
   },
   methods: {
+  // 新規登録時のデータをAPIに送信する
     async registerDataSubmit() {
       const postUserInfo = await this.axios.post(`${API_URL}/user/`, {
-          name: this.userName,
-          email: this.userEmail,
-          password: this.userPassword,
-          password_confirmation: this.userConfirm
+        name: this.userName,
+        email: this.userEmail,
+        password: this.userPassword,
+        password_confirmation: this.userConfirm
       })
-      const createUserResponse = postUserInfo.data
+      const createUserResponse = postUserInfo.data  
       console.log(createUserResponse)
+    },
+  // 新規会員登録ボタンを押した時の処理
+    clickSubmitButton() {
+      this.registerDataSubmit()
+    },
+  },
+
+  updated() {
+    // フォームに入力された値のバリデーション
+    if (this.userName === '' && this.userName.length > 30) {
+      console.log('名前文字数')
+      this.disabled = true
+      return
     }
-  }
+    if (this.userEmail === '' && this.userEmail.length > 100) {
+      console.log('メールアドレス文字数')
+      this.disabled = true
+      return
+    }
+    const emailReg = new RegExp(/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]{1,}\.[A-Za-z0-9]{1,}$/)
+    if (!emailReg.test(this.userEmail)) {
+      console.log('メールアドレスフォーマットが違います')
+      this.disabled = true
+      return
+    }
+    if (this.userPassword === '' && this.userPassword.length < 8) {
+      console.log('パスワード文字数下限')
+      this.disabled = true
+      return
+    }
+    if (this.userPassword.length > 100) {
+      console.log('パスワード文字数上限')
+      this.disabled = true
+      return
+    }
+    const passwordReg = /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,100}$/i
+    if (!passwordReg.test(this.userPassword)) {
+      console.log('パスワードフォーマットが違います')
+      this.disabled = true
+      return
+    }
+    if (this.userPassword !== this.userConfirm) {
+      console.log('確認用パスワードと異なります')
+      this.disabled = true
+      return
+    }
+    this.disabled = false
+  },
 }
 </script>
 

--- a/front/src/components/pages/SignUpPage.vue
+++ b/front/src/components/pages/SignUpPage.vue
@@ -22,7 +22,7 @@
               :class="{ 'bg-blue-300': disabled === true, 'bg-blue-500': disabled === false}"
               class="shadow  focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
               type="button">
-              新規会員登録
+              新規登録
             </button>
           </div>
         </div>
@@ -74,39 +74,32 @@ export default  {
   updated() {
     // フォームに入力された値のバリデーション
     if (this.userName === '' && this.userName.length > 30) {
-      console.log('名前文字数')
       this.disabled = true
       return
     }
     if (this.userEmail === '' && this.userEmail.length > 100) {
-      console.log('メールアドレス文字数')
       this.disabled = true
       return
     }
     const emailReg = new RegExp(/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]{1,}\.[A-Za-z0-9]{1,}$/)
     if (!emailReg.test(this.userEmail)) {
-      console.log('メールアドレスフォーマットが違います')
       this.disabled = true
       return
     }
     if (this.userPassword === '' && this.userPassword.length < 8) {
-      console.log('パスワード文字数下限')
       this.disabled = true
       return
     }
     if (this.userPassword.length > 100) {
-      console.log('パスワード文字数上限')
       this.disabled = true
       return
     }
     const passwordReg = /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,100}$/i
     if (!passwordReg.test(this.userPassword)) {
-      console.log('パスワードフォーマットが違います')
       this.disabled = true
       return
     }
     if (this.userPassword !== this.userConfirm) {
-      console.log('確認用パスワードと異なります')
       this.disabled = true
       return
     }


### PR DESCRIPTION
## 概要
新規登録の各フォームにバリデーション処理を実装しユーザーがフォームから不正なデータを送信できないようにした。

close #24 

## 実装内容
各フォームのバリデーションを実装
- 名前
   - 入力必須、文字数を30文字以下
- メールアドレス
    - 入力必須、文字数を100文字以下、正規表現で形式を指定
- パスワード
    - 入力必須、文字数を8文字以上100文字以下、正規表現で形式を指定
- 確認用パスワード
    - パスワードと同じ内容が入力されているか
 　　
- 新規登録ボタンに関してはバリデーションが全て通るまではdisabledとして押すことができない仕様とした。

## 確認項目
- [ ] 各フォームのバリデーションが適切に実行されているか
- [ ] 適切なデータを入力した場合新規ユーザーが作成されるか
- [ ] レイアウトや見た目が崩れていないか