### PR TITLE
エラーレスポンスが帰ってきた際にバナーを表示する

### DIFF
--- a/front/src/components/UsreForm/ErrorBanner.vue
+++ b/front/src/components/UsreForm/ErrorBanner.vue
@@ -1,0 +1,23 @@
+<template>
+  <div :class="{ 'hidden': bannerShow === false }"
+    class=" bg-red-600 rounded-md absolute top-8 left-0 right-0 mx-auto w-3/5">
+    <div class="max-w-7xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
+      <div class="flex items-center justify-between flex-wrap">
+        <div class="w-0 flex-1 flex justify-center">
+          <p class="ml-3 font-medium text-white truncate">
+            <span>{{ bannerMessage }}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    bannerShow: Boolean,
+    bannerMessage: String
+  }
+}
+</script>

--- a/front/src/components/UsreForm/UserFormConfirm.vue
+++ b/front/src/components/UsreForm/UserFormConfirm.vue
@@ -2,13 +2,13 @@
   <div class="md:flex md:items-center mb-6">
     <div class="md:w-1/3">
       <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-confirm">
-        パスワード確認
+        パスワード<br>確認用
       </label>
     </div>
-    <div class="md:w-2/3">
+    <div class="md:w-4/5">
       <input :value="userConfirm" @input="$emit('update:userConfirm', $event.target.value)"
         class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-500"
-        id="inline-confirm" type="password" placeholder="******************">
+        id="inline-confirm" type="password" placeholder="********">
     </div>
   </div>
 </template>

--- a/front/src/components/UsreForm/UserFormEmail.vue
+++ b/front/src/components/UsreForm/UserFormEmail.vue
@@ -2,10 +2,10 @@
   <div class="md:flex md:items-center mb-6">
     <div class="md:w-1/3">
       <label class="block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" for="inline-email">
-        メールアドレス
+        Eメール
       </label>
     </div>
-    <div class="md:w-2/3">
+    <div class="md:w-4/5">
       <input 
         :value="userEmail" 
         @input="$emit('update:userEmail', $event.target.value)"

--- a/front/src/components/UsreForm/UserFormName.vue
+++ b/front/src/components/UsreForm/UserFormName.vue
@@ -5,12 +5,12 @@
         名前
       </label>
     </div>
-    <div class="md:w-2/3">
+    <div class="md:w-4/5">
       <input 
         :value="userName" 
         @input="$emit('update:userName', $event.target.value)"
         class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-500"
-        id="inline-full-name" type="text" placeholder="筋肉太郎">
+        id="inline-full-name" type="text" placeholder="30文字以内で入力してください">
     </div>
   </div>
 </template>
@@ -25,4 +25,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+input::placeholder {
+  font-size: 0.8em;
+}
 </style>

--- a/front/src/components/UsreForm/UserFormPassword.vue
+++ b/front/src/components/UsreForm/UserFormPassword.vue
@@ -5,12 +5,10 @@
         パスワード
       </label>
     </div>
-    <div class="md:w-2/3">
-      <input 
-        :value="userPassword" 
-        @input="$emit('update:userPassword', $event.target.value)"
+    <div class="md:w-4/5">
+      <input :value="userPassword" @input="$emit('update:userPassword', $event.target.value)"
         class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-blue-500"
-        id="inline-password" type="password" placeholder="******************">
+        id="inline-password" type="password" placeholder="8文字以上で半角英数字を両方含めてください">
     </div>
   </div>
 </template>
@@ -25,4 +23,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+input::placeholder {
+  font-size: 0.7em;
+}
 </style>

--- a/front/src/components/pages/SignUpPage.vue
+++ b/front/src/components/pages/SignUpPage.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="flex justify-center h-full py-14">
     <div class="container lg: py-14">
+      <ErrorBanner :bannerShow="errorBanner" :bannerMessage="errorMessage" />
       <form class="w-full max-w-sm m-auto">
         <UserFormName v-model:user-name="userName" />
         <UserFormEmail v-model:user-email="userEmail" />
@@ -16,9 +17,7 @@
         <div class="md:flex md:items-center">
           <div class="md:w-1/3"></div>
           <div class="md:w-2/3">
-            <button 
-              @click="clickSubmitButton" 
-              :disabled="disabled"
+            <button @click="clickSubmitButton" :disabled="disabled"
               :class="{ 'bg-blue-300': disabled === true, 'bg-blue-500': disabled === false}"
               class="shadow  focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
               type="button">
@@ -32,6 +31,7 @@
 </template>
 
 <script>
+import ErrorBanner from '../UsreForm/ErrorBanner.vue'
 import UserFormName from '../UsreForm/UserFormName.vue'
 import UserFormEmail from '../UsreForm/UserFormEmail.vue'
 import UserFormPassword from '../UsreForm/UserFormPassword.vue'
@@ -39,6 +39,7 @@ import UserFormConfirm from '../UsreForm/UserFormConfirm.vue'
 const API_URL = import.meta.env.VITE_API_URL
 export default  {
   components: {
+    ErrorBanner,
     UserFormName,
     UserFormEmail,
     UserFormPassword,
@@ -47,6 +48,8 @@ export default  {
   data() {
     return {
       disabled: true,
+      errorBanner: false,
+      errorMessage: '',
       userName: '',
       userEmail: '',
       userPassword: '',
@@ -56,14 +59,29 @@ export default  {
   methods: {
   // 新規登録時のデータをAPIに送信する
     async registerDataSubmit() {
-      const postUserInfo = await this.axios.post(`${API_URL}/user/`, {
-        name: this.userName,
-        email: this.userEmail,
-        password: this.userPassword,
-        password_confirmation: this.userConfirm
-      })
-      const createUserResponse = postUserInfo.data  
-      console.log(createUserResponse)
+      try {
+          const postUserInfo = await this.axios.post(`${API_URL}/user/`, {
+          name: this.userName,
+          email: this.userEmail,
+          password: this.userPassword,
+          password_confirmation: this.userConfirm
+        })
+        const createUserResponse = postUserInfo.data  
+        console.log(createUserResponse)
+      }
+      catch (error) {
+        const responseStatusCode = error.response.status
+        if (responseStatusCode === 400) {
+          this.errorMessage = '正しい情報を入力してください'
+          this.errorBanner = true
+          return
+        }
+        if (responseStatusCode === 409) {
+          this.errorMessage = '既に登録済みのメールアドレスです'
+          this.errorBanner = true
+          return
+        }
+      }
     },
   // 新規会員登録ボタンを押した時の処理
     clickSubmitButton() {


### PR DESCRIPTION
## 概要
フォームから不適切な値が送信された場合に返ってくるエラー内容をユーザーが認識できるようにバナーとして表示

close #25 

## やったこと
- エラーレスポンス（400, 409）に対してそれぞれエラーメッセージ付きのバナーを表示
- バナーをコンポーネントに分けて再利用、編集しやすいように実装
- フォームのプレースホルダーの内容を修正

## 確認項目
フォーム側に入力する際のバリデーション処理を実装済みのため確認時は一旦それらのバリデーションを外し不適切な値が遅れる状態で確認を行なった。

- [ ] エラーレスポンスが返ってきた際にバナーが表示されるか
- [ ] エラーレスポンス(400 ,409)に対して適切なエラーメッセージ が表示されるか
- [ ] プレースホルダーの内容は期待しているものに変更されているか

## 確認用スクリーンショット
ステータスコード400の時
<img width="894" alt="スクリーンショット 2022-08-14 16 52 05" src="https://user-images.githubusercontent.com/76101803/184527681-7af65a08-7c9c-4115-8772-b0b1785ca0df.png">

ステータスコード409の時
<img width="890" alt="スクリーンショット 2022-08-14 16 51 32" src="https://user-images.githubusercontent.com/76101803/184527718-8c9ae402-a4ce-4080-80d4-9cc618ba7fa9.png">