### PR TITLE
jwt認証を行う際のサーバー側の処理を実装

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -25,6 +25,9 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# jwt
+gem 'jwt', '~> 2.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    jwt (2.4.1)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -153,6 +154,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.18)
   bootsnap (>= 1.4.2)
   byebug
+  jwt (~> 2.3)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+  include UserAuthenticateService
 end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include UserAuthenticateService
+
+  private
+  
+    def response_500(msg = "Internal Server Error")
+      render status: 500, json: { status: 500, error: msg }
+    end
+
 end

--- a/api/app/controllers/auth_token_controller.rb
+++ b/api/app/controllers/auth_token_controller.rb
@@ -1,0 +1,113 @@
+class AuthTokenController < ApplicationController
+  include UserSessionizeService
+ 
+  rescue_from UserAuth.not_found_exception_class, with: :not_found
+  rescue_from JWT::InvalidJtiError, with: :invalid_jti
+
+  before_action :authenticate, only: [:create]
+  before_action :delete_session, only: [:create]
+  before_action :sessionize_user, only: [:refresh, :destroy]
+
+  # ログイン
+  def create  
+    @user = login_user
+    set_refresh_token_to_cookie
+    render json: login_response
+  end
+
+  # リフレッシュ
+  def refresh
+    @user = session_user
+    set_refresh_token_to_cookie
+    render json: login_response
+  end
+
+  # ログアウト
+  def destroy
+    delete_session if session_user.forget
+    cookies[session_key].nil? ?
+      head(:ok) : response_500("Could not delete session")
+  end 
+
+  private
+
+   # params[:email]からアクティブなユーザーを返す
+   def login_user
+     @_login_user ||= User.find_by(email:auth_params[:email])
+   end
+
+   # ログインユーザーが居ない、もしくはpasswordが一致しない場合404を返す
+   def authenticate
+     unless login_user.present? &&
+            login_user.authenticate(auth_params[:password])
+       raise UserAuth.not_found_exception_class
+     end
+   end
+
+   # refresh_tokenをcookieにセットする
+   def set_refresh_token_to_cookie
+     cookies[session_key] = {
+       value: refresh_token,
+       expires: refresh_token_expiration,
+       secure: Rails.env.production?,
+       http_only: true
+     }
+   end
+
+   # ログイン時のデフォルトレスポンス
+   def login_response
+     {
+       token: access_token,
+       expires: access_token_expiration,
+       user: @user.response_json(sub: access_token_subject)
+     }
+   end
+
+   # リフレッシュトークンのインスタンス生成
+   def encode_refresh_token
+     @_encode_refresh_token ||= @user.encode_refresh_token
+   end
+
+   # リフレッシュトークン
+   def refresh_token
+     encode_refresh_token.token
+   end
+
+   # リフレッシュトークンの有効期限
+   def refresh_token_expiration
+     Time.at(encode_refresh_token.payload[:exp])
+   end
+
+   # アクセストークンのインスタンス生成
+   def encode_access_token
+     @_encode_access_token ||= @user.encode_access_token
+   end
+
+   # アクセストークン
+   def access_token
+     encode_access_token.token
+   end
+
+   # アクセストークンの有効期限
+   def access_token_expiration
+     encode_access_token.payload[:exp]
+   end
+
+   # アクセストークンのsubjectクレーム
+   def access_token_subject
+     encode_access_token.payload[:sub]
+   end
+
+   def not_found
+     head(:not_found)
+   end
+
+   def invalid_jti
+     msg = "Invalid jti for refresh token"
+     render status: 401, json: { status: 401, error: msg }
+   end
+
+   def auth_params
+     params.require(:auth).permit(:email, :password)
+   end
+end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -1,6 +1,8 @@
 class UserController < ApplicationController
+  before_action :authenticate_user
+  
   def index
-    render json:{data: "data"}, status:200
+    render json: current_user.as_json(only: [:id, :name, :email, :created_at])
   end
 
   def create

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -1,5 +1,5 @@
 class UserController < ApplicationController
-  before_action :authenticate_user
+  before_action :authenticate_user, except: [:create]
   
   def index
     render json: current_user.as_json(only: [:id, :name, :email, :created_at])

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
   def forget
     update_column(:refresh_jti, nil)
   end
+
+  def response_json(payload = {})
+    as_json(only: [:id, :name, :email]).merge(payload).with_indifferent_access
+  end
   
   private
     def set_uuid

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include TokenGenerateService   # Token生成モジュール
+
   before_create :set_uuid
   has_secure_password
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
                       length: { maximum: 30 }
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :email, presence: true, uniqueness: true,
+  validates :email, presence: true, uniqueness: { case_sensitive: true }, 
                       length: { maximum: 100 },
                       format: { with: VALID_EMAIL_REGEX }
 
@@ -16,6 +16,15 @@ class User < ApplicationRecord
                       format: { with: VALID_PASSWORD_REGEX }
   validates :password_confirmation, presence: true
 
+  # リフレッシュトークンのJWT IDを記憶する
+  def remember(jti)
+    update_column(:refresh_jti, jti)
+  end
+
+  # リフレッシュトークンのJWT IDを削除する
+  def forget
+    update_column(:refresh_jti, nil)
+  end
   
   private
     def set_uuid

--- a/api/app/services/token_generate_service.rb
+++ b/api/app/services/token_generate_service.rb
@@ -1,0 +1,49 @@
+module TokenGenerateService
+  def self.included(base)
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    # アクセストークンのインスタンス生成(オプション => sub: encrypt user id)
+    def decode_access_token(token, options = {})
+      UserAuth::AccessToken.new(token: token, options: options)
+    end
+
+    # アクセストークンのuserを返す
+    def from_access_token(token, options = {})
+      decode_access_token(token, options).entity_for_user
+    end
+
+    # リフレッシュトークンのインスタンス生成
+    def decode_refresh_token(token)
+      UserAuth::RefreshToken.new(token: token)
+    end
+
+    # リフレッシュトークンのuserを返す
+    def from_refresh_token(token)
+      decode_refresh_token(token).entity_for_user
+    end
+
+  end
+
+  # アクセストークンのインスタンス生成
+  def encode_access_token(payload = {})
+    UserAuth::AccessToken.new(user_id: id, payload: payload)
+  end
+
+  # アクセストークンを返す(期限変更 => lifetime: 10.minute)
+  def to_access_token(payload = {})
+    encode_access_token(payload).token
+  end
+
+  # リフレッシュトークンのインスタンス生成
+  def encode_refresh_token
+    UserAuth::RefreshToken.new(user_id: id)
+  end
+
+  # リフレッシュトークンを返す
+  def to_refresh_token
+    encode_refresh_token.token
+  end
+
+end

--- a/api/app/services/user_auth/access_token.rb
+++ b/api/app/services/user_auth/access_token.rb
@@ -1,0 +1,111 @@
+require 'jwt'
+
+module UserAuth
+  class AccessToken
+    include TokenCommons
+
+    attr_reader :user_id, :payload, :lifetime, :token, :options
+
+    def initialize(user_id: nil, payload: {}, token: nil, options: {})
+      if token.present?
+        # decode
+        @token = token
+        @options = options
+        @payload = JWT.decode(@token.to_s, decode_key, true, verify_claims.merge(@options)).first
+        @user_id = get_user_id_from(@payload)
+      else
+        # encode
+        @user_id = encrypt_for(user_id)
+        @lifetime = payload[:lifetime] || UserAuth.access_token_lifetime
+        @payload = claims.merge(payload.except(:lifetime))
+        @token = JWT.encode(@payload, secret_key, algorithm, header_fields)
+      end
+    end
+
+    # 暗号化された@user_idからユーザーを取得する
+    def entity_for_user
+      User.find(decrypt_for(@user_id))
+    end
+
+    # @lifetimeの日本語テキストを返す
+    def lifetime_text
+      time, period = @lifetime.inspect.sub(/s\z/, "").split
+      case period
+        when 'minute' then
+          return time + '分'
+        when 'houre' then
+          return time + '時間'
+      end
+    end
+
+    private
+
+      ## エンコードメソッド
+
+      # issuerの値がある場合にtrueを返す
+      def verify_issuer?
+        UserAuth.token_issuer.present?
+      end
+
+      # issuerを返す
+      def token_issuer
+        verify_issuer? && UserAuth.token_issuer
+      end
+
+      # audienceの値がある場合にtrueを返す
+      def verify_audience?
+        UserAuth.token_audience.present?
+      end
+
+      # audienceを返す
+      def token_audience
+        verify_audience? && UserAuth.token_audience
+      end
+
+      # user_idの値がある場合にtrueを返す
+      def verify_user_id?
+        @user_id.present?
+      end
+
+      # 有効期限をUnixtimeで返す(必須)
+      def token_expiration
+         @lifetime.from_now.to_i
+      end
+
+      # エンコード時のデフォルトクレーム
+      def claims
+        _claims = {}
+        _claims[:exp] = token_expiration
+        _claims[user_claim] = @user_id if verify_user_id?
+        _claims[:iss] = token_issuer if verify_issuer?
+        _claims[:aud] = token_audience if verify_audience?
+        _claims
+      end
+
+      ## デコードメソッド
+
+      # @optionsにsubjectがある場合にtrueを返す
+      def verify_subject?
+        @options.has_key?(:sub)
+      end
+
+      # @optionsのsubの値を返す
+      def token_subject
+        verify_subject? && @options[:sub]
+      end
+
+      # デコード時のデフォルトオプション
+      def verify_claims
+        {
+          iss: token_issuer,
+          aud: token_audience,
+          sub: token_subject,
+          verify_expiration: true,      # 有効期限の検証するか(必須)
+          verify_iss: verify_issuer?,   
+          verify_aud: verify_audience?, 
+          verify_sub: verify_subject?,  
+          algorithm: algorithm          
+        }
+      end
+  end
+end

--- a/api/app/services/user_auth/refresh_token.rb
+++ b/api/app/services/user_auth/refresh_token.rb
@@ -1,0 +1,90 @@
+require 'jwt'
+
+module UserAuth
+  class RefreshToken
+    include TokenCommons
+
+    attr_reader :user_id, :payload, :token
+
+    def initialize(user_id: nil, token: nil)
+      if token.present?
+        # decode
+        @token = token
+        @payload = JWT.decode(@token.to_s, decode_key, true, verify_claims).first
+        @user_id = get_user_id_from(@payload)
+      else
+        # encode
+        @user_id = encrypt_for(user_id)
+        @payload = claims
+        @token = JWT.encode(@payload, secret_key, algorithm, header_fields)
+        remember_jti(user_id)
+      end
+    end
+
+    # 暗号化されたuserIDからユーザーを取得する
+    def entity_for_user(id = nil)
+      id ||= @user_id
+      User.find(decrypt_for(id))
+    end
+
+    private
+
+      # リフレッシュトークンの有効期限
+      def token_lifetime
+        UserAuth.refresh_token_lifetime
+      end
+
+      # 有効期限をUnixtimeで返す(必須)
+      def token_expiration
+         token_lifetime.from_now.to_i
+      end
+
+      # jwt_idの生成(必須)
+      # Digest::MD5.hexdigest => 複合不可のハッシュを返す
+      # SecureRandom.uuid => 一意性の値を返す
+      def jwt_id
+        Digest::MD5.hexdigest(SecureRandom.uuid)
+      end
+
+      # エンコード時のデフォルトクレーム
+      def claims
+        {
+          user_claim => @user_id,
+          jti: jwt_id,
+          exp: token_expiration
+        }
+      end
+
+      # @payloadのjtiを返す
+      def payload_jti
+        @payload.with_indifferent_access[:jti]
+      end
+
+      # jtiをUsersテーブルに保存する
+      def remember_jti(user_id)
+        User.find(user_id).remember(payload_jti)
+      end
+
+      ##  デコードメソッド
+
+      # デコード時のjwt_idを検証する(エラーはJWT::DecodeErrorに委託する)
+      def verify_jti?(jti, payload)
+        user_id = get_user_id_from(payload)
+        decode_user = entity_for_user(user_id)
+        decode_user.refresh_jti == jti
+      rescue UserAuth.not_found_exception_class
+        false
+      end
+
+      # デコード時のデフォルトオプション
+      def verify_claims
+        {
+          verify_expiration: true,           # 有効期限の検証するか(必須)
+          verify_jti: proc { |jti, payload|  # jtiとセッションIDの検証
+            verify_jti?(jti, payload)
+          },
+          algorithm: algorithm               # decode時のアルゴリズム
+        }
+      end
+  end
+end

--- a/api/app/services/user_auth/token_commons.rb
+++ b/api/app/services/user_auth/token_commons.rb
@@ -1,0 +1,60 @@
+module UserAuth
+  module TokenCommons
+
+    # エンコードキー
+    def secret_key
+      UserAuth.token_secret_signature_key
+    end
+
+    # デコードキー
+    def decode_key
+      UserAuth.token_public_key || secret_key
+    end
+
+    # アルゴリズム
+    def algorithm
+      UserAuth.token_signature_algorithm
+    end
+
+    # user識別クレーム
+    def user_claim
+      UserAuth.user_claim
+    end
+
+    # キーがハッシュでも文字列でもuser_claimの値を返す
+    def get_user_id_from(payload)
+      payload.with_indifferent_access[user_claim]
+    end
+
+    # 暗号化クラスの生成
+    def crypt
+      salt = "signed user id"
+      key_length = ActiveSupport::MessageEncryptor.key_len
+      secret = Rails.application.key_generator.generate_key(salt, key_length)
+      ActiveSupport::MessageEncryptor.new(secret)
+    end
+
+    # user_id暗号化
+    def encrypt_for(user_id)
+      return unless user_id
+      crypt.encrypt_and_sign(user_id.to_s, purpose: :authorization)
+    end
+
+    # user_id複合化(複合エラーの場合はnilを返す)
+    def decrypt_for(user_id)
+      return unless user_id
+      crypt.decrypt_and_verify(user_id.to_s, purpose: :authorization)
+    rescue
+      nil
+    end
+
+    # エンコード時のヘッダー
+    def header_fields
+      {
+        typ: "JWT",
+        alg: algorithm
+      }
+    end
+
+  end
+end

--- a/api/app/services/user_authenticate_service.rb
+++ b/api/app/services/user_authenticate_service.rb
@@ -1,0 +1,38 @@
+module UserAuthenticateService
+  # 認証する際トークンの持ち主が存在するか判定
+  def authenticate_user
+    current_user.present? || unauthorized_user
+  end
+
+  # トークンの持ち主かつメール認証ユーザーをが存在するか判定
+  def authenticate_active_user
+    (current_user.present? && current_user.activated?) || unauthorized_user
+  end
+
+  private
+
+    # リクエストヘッダートークンを取得する
+    def token_from_request_headers
+      request.headers["Authorization"]&.split&.last
+    end
+
+    # access_tokenから有効なユーザーを取得する
+    def fetch_user_from_access_token
+      User.from_access_token(token_from_request_headers)
+    rescue UserAuth.not_found_exception_class,
+           JWT::DecodeError, JWT::EncodeError
+      nil
+    end
+
+    # tokenのユーザーを返す
+    def current_user
+      return nil unless token_from_request_headers
+      @_current_user ||= fetch_user_from_access_token
+    end
+
+    # 認証エラー
+    def unauthorized_user
+      cookies.delete(UserAuth.session_key)
+      head(:unauthorized)
+    end
+end

--- a/api/app/services/user_sessionize_service.rb
+++ b/api/app/services/user_sessionize_service.rb
@@ -1,0 +1,44 @@
+module UserSessionizeService
+
+  # セッションユーザーが居ればtrue、存在しない場合は401を返す
+  def sessionize_user
+    session_user.present? || unauthorized_user
+  end
+
+  # セッションキー
+  def session_key
+    UserAuth.session_key
+  end
+
+  # セッションcookieを削除する
+  def delete_session
+    cookies.delete(session_key)
+  end
+
+  private
+
+    # cookieのtokenを取得
+    def token_from_cookies
+      cookies[session_key]
+    end
+
+    # refresh_tokenから有効なユーザーを取得する
+    def fetch_user_from_refresh_token
+      User.from_refresh_token(token_from_cookies)
+    rescue UserAuth.not_found_exception_class,
+           JWT::DecodeError, JWT::EncodeError
+      nil
+    end
+
+    # refresh_tokenのユーザーを返す
+    def session_user
+      return nil unless token_from_cookies
+      @_session_user ||= fetch_user_from_refresh_token
+    end
+
+    # 認証エラー
+    def unauthorized_user
+      delete_session
+      head(:unauthorized)
+    end
+end

--- a/api/config/initializers/user_auth.rb
+++ b/api/config/initializers/user_auth.rb
@@ -1,0 +1,41 @@
+ module UserAuth
+  # access tokenの有効期限
+  mattr_accessor :access_token_lifetime
+  self.access_token_lifetime = 30.minute
+
+  # refresh tokenの有効期限
+  mattr_accessor :refresh_token_lifetime
+  self.refresh_token_lifetime = 1.day
+
+  # cookieからrefresh tokenを取得する際のキー
+  mattr_accessor :session_key
+  self.session_key = :refresh_token
+
+  # userを識別するクレーム名
+  mattr_accessor :user_claim
+  self.user_claim = :sub
+
+  # JWTの発行者を識別する文字列(認可サーバーURL)
+  mattr_accessor :token_issuer
+  self.token_issuer = ENV["BASE_URL"]
+
+  # JWTの受信者を識別する文字列(保護リソースURL)
+  mattr_accessor :token_audience
+  self.token_audience = ENV["BASE_URL"]
+
+  # JWTの署名アルゴリズム
+  mattr_accessor :token_signature_algorithm
+  self.token_signature_algorithm = "HS256"
+
+  # 署名・検証に使用する秘密鍵
+  mattr_accessor :token_secret_signature_key
+  self.token_secret_signature_key = Rails.application.credentials.secret_key_base
+
+  # 署名・検証に使用する公開鍵(RS256)
+  mattr_accessor :token_public_key
+  self.token_public_key = nil
+
+  # ユーザーが見つからない場合のエラーを指定
+  mattr_accessor :not_found_exception_class
+  self.not_found_exception_class = ActiveRecord::RecordNotFound
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   resources :user
+
+  resources :auth_token, only:[:create] do
+    post :refresh, on: :collection
+    delete :destroy, on: :collection
+  end
 end

--- a/api/db/migrate/20220817122540_add_refresh_jti_to_users.rb
+++ b/api/db/migrate/20220817122540_add_refresh_jti_to_users.rb
@@ -1,0 +1,5 @@
+class AddRefreshJtiToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :refresh_jti, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_31_154843) do
+ActiveRecord::Schema.define(version: 2022_08_17_122540) do
 
   create_table "users", id: :string, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2022_07_31_154843) do
     t.string "password_confirmation"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "refresh_jti"
   end
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - "./api:/$WORKDIR"
     environment:
       MYSQL_ROOT_PASSWORD: $MYSQL_ROOT_PASSWORD
+      BASE_URL: "http://localhost:8000"
     ports:
       - "8000:3000"
     # dbコンテナ起動後にapiコンテナを起動


### PR DESCRIPTION
## 概要
ログイン認証を実装するにあたってjwtを使用したトークン認証を採用した。
トークンの管理はクッキーに保存してサーバー側のものと照合するように実装した。
認証方法に関してはアクセストークンとリフレッシュトークンの二つを使用するように設計した。初回ログイン時にはアクセストークンを発行し認証、時間の経過に伴ってリフレッシュトークンを発行し情報を更新することで認証を行いログイン状態を管理するように実装した。

close #28 

## 実装内容
- **jwtのインストールと初期設定ファイルの作成**
  - アクセストークンの有効期限を30分に設定
  - リフレッシュトークンの有効期限を1日に設定
  - 署名アルゴリズムとしてHS256を使用
  - subというクレームにユーザー情報を格納
- **ユーザーごとのリフレッシュトークンの情報を保持するためにカラムを追加**
  - 下記のカラムにリフレッシュトークンを格納  
  `t.string "refresh_jti"`
- **トークン発行をする際に使用するメソッドをまとめたモジュールを作成**
services/token_generrate_service.rb
- **リフレッシュトークンを操作するためのメソッドをまとめたモジュールを作成**  
services/user_auth/refresh_token.rb
- **リフレッシュトークンを操作するためのメソッドをまとめたモジュールを作成**  
services/user_auth/access_token.rb
- **トークンの使用を簡単にするためのモジュールを作成**
services/user_auth/token_common.rb
- **current_userを取得しログイン情報を管理するためのメソッドをまとめたモジュールを作成**
services/user_authenticate_service.rb
- **セッション情報をCookieで管理するためのモジュールを作成**  
services/user_sessionaize_service.rb
- **認証を行うコントローラーを作成**
controllers/auth_token_controller.rb

## 認証手順
### 初回ログイン時
1. フロント側からログイン情報(email,password)を送信
2. サーバー側で情報と一致するユーザーを検索し、存在する場合にアクセストークンとリフレッシュトークンを発行する。ユーザーテーブルにリフレッシュトークンIDを保存し、CookieにもリフレッシュトークンIDを保存する。
3. フロント(Vue.js)にはアクセストークンとその有効期限、ユーザー情報を返す。
→ ユーザーがいない場合は404(NotFound)コードを返す

### ログイン状態を保持する
1. アクセストークンの有効期限である30分が切れた時にフロント側からサイレントリフレッシュとしてサーバーにリクエストを送信する。(未実装)
2. 1でCookieに保存したリフレッシュトークンを送信した際にサーバー側のUserテーブルに保存されているリフレッシュトークンと照合する。
3. 2で照合した結果が一致していた場合サーバーから新しいアクセストークンとリフレッシュトークンを発行する。
4. リフレッシュトークンをCookieとUserテーブルに保存する
5. フロント側にアクセストークンとその有効期限、ユーザー情報を返す
→ 2でリフレッシュトークンが一致していない場合は401（未認証）コードを返す


## 動作確認
下記コマンドにてログイン時にトークンとその他ユーザー情報を返すことを確認済み
 auth_token#create
```
curl -X POST http://localhost:8000/auth_token \
-H "Content-Type: application/json" \
-d '{"auth": {"email": "haruto@i.softbank.jp", "password": "haruto"}}'
```
トークン、有効期限期限、ユーザ情報が返されていることが確認できる。
`{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2NjE2NTAzMTMsInN1YiI6InFyQ3pjM0FQSjZaUlVwVVdwem11aGw3YWJYUGZ5ZGJCaXdCdjA4ZTV6cDhOZ3crRDBCZkVjVldOL0JQNG5ZanlwSXBvdDU1NUZyNTljZk9PcnZCZTBpQ3ZTZnR1QUUyc2c5aCtiTE83SzQ0R293cVA0RjBvR0FFbVhBbDNBVjdFZ01BPS0tMlkwQ3MyVmtVNkZsUkhtSy0tY2xRTldYUFpFWGV4RSsrb1J3cEt5QT09IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo4MDAwIn0.Qcm1B-CWr_NquF_bn4en5ZAyo-VuumY3CI5KLopelno","expires":1661650313,"user":{"id":"4O9mCXbB0nZHnYZPyhfg","name":"aaaa","email":"haruto@i.softbank.jp","sub":"qrCzc3APJ6ZRUpUWpzmuhl7abXPfydbBiwBv08e5zp8Ngw+D0BfEcVWN/BP4nYjypIpot555Fr59cfOOrvBe0iCvSftuAE2sg9h+bLO7K44GowqP4F0oGAEmXAl3AV7EgMA=--2Y0Cs2VkU6FlRHmK--clQNWXPZEXexE++oRwpKyA=="}}% `

`curl http://localhost:8000/user`でアクセスしたところ401が返ってくることを確認済み
authenticate_userメソッドをコメントアウトしたところユーザー情報が帰ってくることを確認済み