### PR TITLE
ユーザ情報設定用ボタンとログアウトボタンを表示するドロワーを作成

### DIFF
--- a/front/src/components/HeaderBar/HeaderUserinfo.vue
+++ b/front/src/components/HeaderBar/HeaderUserinfo.vue
@@ -1,20 +1,51 @@
 <template>
-<a href="#" class="flex-shrink-0 group block">
-  <div class="flex items-center group-hover:opacity-60 duration-200">
-    <div>
-      <img class="inline-block  md:h-10 md:w-10 h-9 w-9  rounded-full" src="https://pbs.twimg.com/profile_images/1121328878142853120/e-rpjoJi_bigger.png" alt="" />
-    </div>
-    <div class="ml-3 hidden md:block">
-      <p class="text-sm leading-6 font-medium">
-        筋トレ 太郎
-      </p>
+  <div ref="wrapper" class="relative settingDrawer_wrapper">
+    <a href="#" class="flex-shrink-0 group block" @click="showDrower">
+      <div class="flex items-center group-hover:opacity-60 duration-200">
+        <div>
+          <img class="inline-block  md:h-10 md:w-10 h-9 w-9  rounded-full"
+            src="https://pbs.twimg.com/profile_images/1121328878142853120/e-rpjoJi_bigger.png" alt="" />
+        </div>
+        <div class="ml-3 hidden md:block">
+          <p class="text-sm leading-6 font-medium">
+            筋トレ 太郎
+          </p>
+        </div>
+      </div>
+    </a>
+    <div class="absolute top-11 p-5 shadow-lg text-sm bg-white" v-if="settingDrower">
+      <div class="mb-2 cursor-pointer">設定</div>
+      <div class="cursor-pointer" @click="Logout">ログアウト</div>
     </div>
   </div>
-</a>
 </template>
 
 <script>
+import { authLoginMethods } from '../../../mixins/auth.js'
 export default {
-  
+  mixins: [authLoginMethods],
+  data() {
+    return {
+      settingDrower: false,
+    }
+  },
+  methods: {
+    showDrower() {
+      this.settingDrower = !this.settingDrower
+    },
+    async Logout() {
+      await this.logout()
+      this.$router.push('/login')
+    }
+  },
+  mounted() {
+    const $this = this
+    document.addEventListener("click", function (e) {
+      const target = (e.target).closest(".settingDrawer_wrapper");
+      if (target === null) {
+        $this.settingDrower = false
+      }
+    });
+  }
 }
 </script>


### PR DESCRIPTION
### 概要
ユーザ情報を設定するボタンとログアウトボタンを表示するドロワーを作成
close #34 

## やったこと
- クリックすると表示されるドロワーを作成
- ドロワーの中に設定ボタンとログアウトボタンを追加
  - ログアウトボタンにはログアウト用のメソッドを追加
- ドロワー以外の場所をクリックするとドロワーが閉じるように作成

## 確認事項
- [x] クリック時ドロワーが正常に表示されるか 
- [x] ドロワー以外をクリック時に正常にドロワーが閉じるか
- [x] 設定とログアウトのボタンが正しく表示されているか
- [x] ログアウトボタンは動作するか

## 確認用スクリーンショット
![スクリーンショット 2022-09-10 17 59 04](https://user-images.githubusercontent.com/76101803/189476485-6ef63805-ee23-4a61-9038-9ddd05d570a5.png)

## その他
今後ドロワーのデザインを変更する
設定用ボタンを動作するように機能を実装する