### PR TITLE
ログイン状態を維持できるように機能を追加

### DIFF
--- a/front/mixins/auth.js
+++ b/front/mixins/auth.js
@@ -1,4 +1,5 @@
 import jwtDecode from 'jwt-decode'
+import { store } from '../store/index.js'
 
 export const authLoginMethods = {
   methods: {
@@ -7,10 +8,10 @@ export const authLoginMethods = {
       const exp = expires * 1000
       const jwtPayload = (token) ? jwtDecode(token) : {}
       
-      this.$store.dispatch('getAuthToken', token)
-      this.$store.dispatch('getAuthExpires', exp)
-      this.$store.dispatch('getCurrentUser', user)
-      this.$store.dispatch('getAuthPayload', jwtPayload)
+      store.dispatch('getAuthToken', token)
+      store.dispatch('getAuthExpires', exp)
+      store.dispatch('getCurrentUser', user)
+      store.dispatch('getAuthPayload', jwtPayload)
     },
   // ログイン時のメソッド
     login (response) {

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -2,6 +2,8 @@ import { createRouter, createWebHistory } from "vue-router";
 import HomePage from "../components/pages/HomePage.vue";
 import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
+import axios from "axios";
+import { authLoginMethods } from '../../mixins/auth.js'
 
 const routes = [
   {
@@ -26,4 +28,15 @@ const router = createRouter({
   routes,
 });
 
-export default router;
+router.beforeResolve(async (to) => {
+  if (to.fullPath === '/login' || to.fullPath === '/signup') {
+    return
+  }
+    await axios.post(
+      '/auth_token/refresh',
+      {},
+      { validateStatus: status => authLoginMethods.methods.resolveUnauthorized(status) }
+      ).then(response => authLoginMethods.methods.login(response.data))
+  })
+
+export default router


### PR DESCRIPTION
## 概要
ログイン情報をVuexのストアに保存していたためリロードをするとデータが消えてしまっていたためログイン状態の維持ができなかった。そのためvue-routerのナビゲーションガードを使用し、ログイン画面と新規登録画面以外ではaxosでrefresh_tokenを送信し、レスポンスの結果を再度Vuexに保存する形でログイン状態を維持できるようにした。

close #37


## やったこと
- Vuerouterのナビゲーションガードを使用し、ルーティング前の処理を追加
  - axiosにてAPIと通信を行い新しいrefresh_tokenを発行してもらい、レスポンスとして受けったものを再度Vuexに保存することでログイン状態を維持するようにした
  - /login, ,signupは処理を行わないように実装
    - ログインしていない状態で上記のAPI通信をしても401を返すため 

## 確認項目
- [x] ログイン中にページをリロードしてもVuexのデータが削除されていないか
- [x] ログイン中にCookieのリフレッシュトークンを削除、改竄してリロードした場合に401が返されるか
- [x] ログイン、新規登録画面ではナビゲーションガードの処理が走っていないか

## その他
auth.jsにVuexを読み込みstoreを使用できるように修正した