### PR TITLE
ユーザーの認証状態に応じてリダイレクトを行うように実装

### DIFF
--- a/front/mixins/auth.js
+++ b/front/mixins/auth.js
@@ -1,4 +1,5 @@
 import jwtDecode from 'jwt-decode'
+import axios from 'axios'
 import { store } from '../store/index.js'
 
 export const authLoginMethods = {
@@ -28,13 +29,35 @@ export const authLoginMethods = {
       return (status >= 200 && status < 300) || (status === 401)
     },
 
-    // ログアウト時のメソッド
+  // ログアウト時のメソッド
     async logout() {
-      await this.axios.delete(
+      await axios.delete(
         '/auth_token/',
         { validateStatus: status => this.resolveUnauthorized(status) }
       )
       this.resetVuex()
+    },
+    
+   // 有効期限内にtrueを返す
+    isAuthenticated() {
+      return new Date().getTime() < store.getters.auth_expires
+    },
+
+  // ユーザーが存在している場合はtrueを返す
+    isExistUser() {
+      const user_sub = store.getters.current_user.sub
+      const payload_sub = store.getters.auth_payload.sub
+      return user_sub && payload_sub && user_sub === payload_sub
+    },
+
+  // ユーザーが存在し、かつ有効期限切れの場合にtrueを返す
+    isExistUserAndExpired () {
+      return this.isExistUser() && !this.isAuthenticated()
+    },
+
+  // ユーザーが存在し、かつ有効期限内の場合にtrueを返す
+    loggedIn () {
+      return this.isExistUser() && this.isAuthenticated()
     }
 	}
 }

--- a/front/plugins/silent-refresh-token.js
+++ b/front/plugins/silent-refresh-token.js
@@ -1,42 +1,19 @@
 import axios from "axios";
 import { authLoginMethods } from '../mixins/auth.js'
 import router from '../src/router'
-import { store } from '../store/index.js'
-
 
 const silent_refresh_method = async () => {
-   // 有効期限内にtrueを返す
-    function isAuthenticated() {
-      return new Date().getTime() < store.getters.auth_expires
-    }
-
-  // ユーザーが存在している場合はtrueを返す
-    function isExistUser() {
-      const user_sub = store.getters.current_user.sub
-      const payload_sub = store.getters.auth_payload.sub
-      return user_sub && payload_sub && user_sub === payload_sub
-    }
-
-  // ユーザーが存在し、かつ有効期限切れの場合にtrueを返す
-    function isExistUserAndExpired() {
-      return isExistUser() && !isAuthenticated()
-    }
-
-  // ユーザーが存在し、かつ有効期限内の場合にtrueを返す
-    function loggedIn () {
-      return isExistUser() && isAuthenticated()
-    }
-  
-  if (isExistUserAndExpired()) {
+  const auth = authLoginMethods.methods
+  if (auth.isExistUserAndExpired()) {
     await axios.post('/auth_token/refresh')
-      .then( response => authLoginMethods.methods.login(response.data))
-      .catch(() => {
+      .then( response => auth.login(response.data))
+      .catch((error) => {
         const msg = 'セッションの有効期限が切れました。' +
           'もう一度ログインしてください'
         console.log(msg)
 
-        authLoginMethods.methods.resetVuex()
-        router.push('/login')
+        auth.resetVuex()
+        router.push({ path:'login', query: {auth:'expired'}})
       })
   }
 }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -1,28 +1,4 @@
-<script>
-import { authLoginMethods } from '../mixins/auth.js'
-export default {
-  mixins: [authLoginMethods],
-  async mounted() {
-    if (location.pathname === '/login' || location.pathname === '/signup') {
-      return
-    }
-
-  // 画面描画時に通信を行いVuexにログインデータを保存する
-    await this.axios.post(
-      '/auth_token/refresh',
-      {},
-      { validateStatus: status => this.resolveUnauthorized(status) }
-    )
-      .then(response => this.login(response.data))
-
-  // 画面描画時にログイン情報がセットされていない場合はログイン画面に遷移
-    if (!this.$store.state.user.current && !this.$store.state.auth.token &&
-      !this.$store.state.expirs && !this.$store.state.sub
-    ) {
-      this.$router.push('/login')
-    }
-  }
-}
+<script setup>
 </script>
 
 <template>

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -4,6 +4,7 @@ import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
 import { authLoginMethods } from '../../mixins/auth.js'
+// import { store } from '../../store/index.js'
 import axios from 'axios'
 
 const routes = [
@@ -30,8 +31,15 @@ const router = createRouter({
 });
 
 const auth = authLoginMethods.methods
-router.beforeEach(async () => {
-
+router.beforeEach(async (to,from) => {
+  // ログアウト時の画面遷移では何もしない
+  if (from.path !== '/' && to.path === '/login') {
+    return
+  }
+  // 認証が失敗した際の画面遷移では何もしない
+  if (to.query.auth) {
+    return
+  }
   // ログインしているユーザー情報がセットされていなければ取得する
   if (!auth.isExistUser()) {
     await axios.post(
@@ -44,6 +52,24 @@ router.beforeEach(async () => {
 
   // 画面遷移時にトークンの有効期限が切れていないか判断する
   await silent_refresh()
+
+  // ログインしている場合
+  if (to.path === '/login' || to.path === '/signup') {
+    if (auth.loggedIn()) {
+      console.log('ログイン済みユーザーです')
+      router.push('/home')
+    }
+  }
+  else {
+    // ログインしていない場合
+    if (!auth.loggedIn()) {       
+      // ユーザー以外の値が存在する可能性があるので全てを削除する
+      await auth.logout()
+
+      console.log('まずはログインしてください')
+      router.push({ path:'login', query:{auth:'uncertified'}})
+    }
+  }
 })
 
 export default router


### PR DESCRIPTION
## 概要
ユーザーの認証状態に応じてリダイレクトを行うように実装

close #40  resolve #36

## やったこと
- App.vueにまとめてあった画面描画時の処理をルーティング前に行う処理に移動させた。
  - それに伴い必要な処理をauth.jsにまとめた
  - ルーティング前のビフォアガードでAPI通信を行いログイン情報を取得してくる
- ルーティングする際にログインしている場合としていない場合でのリダイレクト処理を実装
  - ログインしている場合に/login,/signupにアクセスした場合は/homeにリダイレクト
  - ログインしていない場合に/home(ログインが必要な画面)にアクセスした場合は/loginにリダイレクト

確認項目
- [x] 意図したタイミングで適切に意図したURLにリダイレクトされているか
- [x] 処理を写した関係で動いていない、バグが発生している機能はないか
  