### PR TITLE
エラー内容を表示するためのグローバルトースターを表示

### DIFF
--- a/front/plugins/silent-refresh-token.js
+++ b/front/plugins/silent-refresh-token.js
@@ -1,18 +1,19 @@
 import axios from "axios";
 import { authLoginMethods } from '../mixins/auth.js'
 import router from '../src/router'
+import { store } from '../store/index.js'
 
 const silent_refresh_method = async () => {
   const auth = authLoginMethods.methods
   if (auth.isExistUserAndExpired()) {
     await axios.post('/auth_token/refresh')
       .then( response => auth.login(response.data))
-      .catch((error) => {
-        const msg = 'セッションの有効期限が切れました。' +
+      .catch(() => {
+        const message = 'セッションの有効期限が切れました。\n' +
           'もう一度ログインしてください'
-        console.log(msg)
 
         auth.resetVuex()
+        store.dispatch('getToast', {message})
         router.push({ path:'login', query: {auth:'expired'}})
       })
   }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -1,8 +1,25 @@
-<script setup>
+<script>
+  import Toaster from './components/AppToaster.vue' 
+export default {
+  components: {
+    Toaster
+  },
+  methods: {
+    test() {
+      const message = 'test'
+      const color = 'bg-red-500'
+      this.$store.dispatch('getToast', {message, color})
+    }
+  }    
+
+}
 </script>
 
 <template>
+  <button @click = "test">test</button>
+  <Toaster />
   <router-view></router-view>
+
 </template>
 
 <style scoped>

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -4,22 +4,12 @@ export default {
   components: {
     Toaster
   },
-  methods: {
-    test() {
-      const message = 'test'
-      const color = 'bg-red-500'
-      this.$store.dispatch('getToast', {message, color})
-    }
-  }    
-
 }
 </script>
 
 <template>
-  <button @click = "test">test</button>
   <Toaster />
   <router-view></router-view>
-
 </template>
 
 <style scoped>

--- a/front/src/components/AppToaster.vue
+++ b/front/src/components/AppToaster.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="bg-red-500 rounded-md z-40 fixed top-9 right-0 left-0 mx-auto w-1/2">
+    <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
+      <div class="flex flex-wrap items-center justify-between">
+        <div class="flex w-0 flex-1 items-center">
+          <p class="ml-3 truncate font-medium text-white">
+            <span>toast message</span>
+          </p>
+        </div>
+        <div class="order-2 flex-shrink-0 sm:order-3 sm:ml-3">
+          <button type="button" class="-mr-1 flex rounded-md p-2">
+            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          </button>
+        </div>
+      </div>
+    </div>          
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/front/src/components/AppToaster.vue
+++ b/front/src/components/AppToaster.vue
@@ -1,14 +1,20 @@
 <template>
-  <div class="bg-red-500 rounded-md z-40 fixed top-9 right-0 left-0 mx-auto w-1/2">
+  <div
+   v-if="setToaster"
+   v-bind:class = this.toast.color
+   class=" rounded-md z-40 fixed top-9 right-0 left-0 mx-auto w-1/2"
+   >
     <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
       <div class="flex flex-wrap items-center justify-between">
         <div class="flex w-0 flex-1 items-center">
           <p class="ml-3 truncate font-medium text-white">
-            <span>toast message</span>
+            {{toast.message}}
           </p>
         </div>
         <div class="order-2 flex-shrink-0 sm:order-3 sm:ml-3">
-          <button type="button" class="-mr-1 flex rounded-md p-2">
+          <button type="button" class="-mr-1 flex rounded-md p-2"
+          @click="resetToast"
+          >
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
           </button>
         </div>
@@ -19,6 +25,26 @@
 
 <script>
 export default {
-
+  computed: {
+    toast() {
+      return this.$store.state.toast
+    },
+    setToaster() {
+      if (!!this.toast.message) {
+        setTimeout(() => {this.resetToast()}, this.toast.timeout)
+        return true
+      }
+    }
+  },
+  beforeDestroy () {
+    // Vueインスタンスが破棄される直前にVuexのtoast.msgを削除する(無期限toastに対応)
+    this.resetToast()
+  },
+  methods: {
+    // Vuexのtoast.msgの値を変更する
+    resetToast() {
+      return this.$store.dispatch('getToast', { message: null })
+    }
+  }
 }
 </script>

--- a/front/src/components/AppToaster.vue
+++ b/front/src/components/AppToaster.vue
@@ -7,7 +7,7 @@
     <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
       <div class="flex flex-wrap items-center justify-between">
         <div class="flex w-0 flex-1 items-center">
-          <p class="ml-3 truncate font-medium text-white">
+          <p class="ml-3 whitespace-pre-line font-medium text-white break-normal">
             {{toast.message}}
           </p>
         </div>
@@ -31,7 +31,12 @@ export default {
     },
     setToaster() {
       if (!!this.toast.message) {
-        setTimeout(() => {this.resetToast()}, this.toast.timeout)
+        setTimeout(() => {
+          if (this.toast.timeout === -1) {
+            return
+          }
+          this.resetToast()
+        }, this.toast.timeout)
         return true
       }
     }

--- a/front/src/components/pages/LoginPage.vue
+++ b/front/src/components/pages/LoginPage.vue
@@ -60,9 +60,9 @@ export default {
       this.$router.push('/home')
     },
     authFailure(error) {
-      console.log('失敗')
       if (error && error.response.status === 404) {
-        console.log(error)
+        const message = 'ユーザーが見つかりません'
+        this.$store.dispatch('getToast', {message})
       }
     }
   }

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -4,7 +4,7 @@ import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
 import { authLoginMethods } from '../../mixins/auth.js'
-// import { store } from '../../store/index.js'
+import { store } from '../../store/index.js'
 import axios from 'axios'
 
 const routes = [
@@ -50,9 +50,6 @@ router.beforeEach(async (to,from) => {
       .then(response => auth.login(response.data))
   }
 
-  // 画面遷移時にトークンの有効期限が切れていないか判断する
-  await silent_refresh()
-
   // ログインしている場合
   if (to.path === '/login' || to.path === '/signup') {
     if (auth.loggedIn()) {
@@ -62,14 +59,17 @@ router.beforeEach(async (to,from) => {
   }
   else {
     // ログインしていない場合
-    if (!auth.loggedIn()) {       
+    if (!auth.isExistUser()) {       
       // ユーザー以外の値が存在する可能性があるので全てを削除する
       await auth.logout()
 
-      console.log('まずはログインしてください')
+      const message = 'まずはログインしてください'
+      store.dispatch('getToast', {message})
       router.push({ path:'login', query:{auth:'uncertified'}})
     }
   }
+  // 画面遷移時にトークンの有効期限が切れていないか判断する
+  await silent_refresh()
 })
 
 export default router

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -10,6 +10,11 @@ export const store = createStore({
         token: null,
         expires: 0,
         payload: {}
+      },
+      toast: {
+        message: null,
+        color: 'bg-red-500',
+        timeout: 4000
       }
     }
   },
@@ -25,6 +30,9 @@ export const store = createStore({
     },
     setAuthPayload (state, payload) {
       state.auth.payload = payload
+    },
+    setToast (state, payload) {
+      state.toast = payload
     }
   },
   actions: {
@@ -41,6 +49,11 @@ export const store = createStore({
     getAuthPayload ({ commit }, jwtPayload) {
       jwtPayload = jwtPayload || {}
       commit('setAuthPayload', jwtPayload)
+    },
+    getToast({ commit }, { message, color, timeout }) {
+      color = color || 'bg-red-500'
+      timeout = timeout || 4000
+      commit('setToast', { message, color, timeout})
     }
   },
   getters: {


### PR DESCRIPTION
## 概要
ログイン失敗時やセッションの有効期限が切れた際に画面遷移をした後、ユーザーが何が起こったのか理解できるようにトースターとしてエラーを出力する。
このトースターはメソッド一つで呼び出すことができ、どのコンポーネントでも使うことができるコンポーネントとして作成した
close #43 

## やったこと
* トースターのテンプレートとしてコンポーネントを作成
* コンポーネントをVuexのメソッドを使用してどのコンポーネントからでも呼び出せるように実装
* トースターを出力した際には4秒後に自動的に消えるようにしている。×を押しても消える
実際にエラーが起こった際、任意のメッセージと共に出力できるように実装
現段階では三箇所に追加
  * ログインに失敗した時
  * 未ログインの状態でログインが必要なページにアクセスした時
  * トークンの有効期限が切れ、ログイン状態を維持できなくなった時
## 確認項目
- [x] グローバルトースターとしてどのコンポーネントからでも任意のメッセージを引数として渡すことで出力できる実装になっているか
- [x] 意図したタイミングでトースターを出力できているか
- [x] 意図した表示になっているか
- [x] 他のレイアウトが崩れていないか

## その他
こちらは色の指定を修正することでエラー以外のトースターとしても出力が可能である。