### PR TITLE
エラー用のページを作成・表示

### DIFF
--- a/front/src/components/pages/error/InternalServerError.vue
+++ b/front/src/components/pages/error/InternalServerError.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="justify-center flex">
+    <div class="mt-16 p-16 border-2 border-solid rounded-lg">
+      <h1 class="text-center text-5xl mb-4">500 Internal Server Error</h1>
+      <p class="text-center text-xl">サーバーに問題が発生しています</p>
+    </div>
+  </div>
+</template>

--- a/front/src/components/pages/error/NotFound.vue
+++ b/front/src/components/pages/error/NotFound.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="justify-center flex">
+    <div class="mt-16 p-16 border-2 border-solid rounded-lg border-red-500 bg-red-100">
+      <h1 class="text-center text-red-600 text-5xl mb-4">404 Not Found</h1>
+      <p class="text-center text-red-600 text-xl">存在しないページです</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  
+}
+</script>

--- a/front/src/components/pages/error/NotFound.vue
+++ b/front/src/components/pages/error/NotFound.vue
@@ -6,9 +6,3 @@
     </div>
   </div>
 </template>
-
-<script>
-export default {
-  
-}
-</script>

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -11,8 +11,14 @@ const API_URL = import.meta.env.VITE_API_URL
 axios.defaults.baseURL = API_URL
 axios.defaults.withCredentials = true
 
+
 const app = createApp(App)
-  app.use(VueRouter)
-  app.use(VueAxios, axios)
-  app.use(store)
-  app.mount('#app')
+app.use(VueRouter)
+app.use(VueAxios, axios)
+app.use(store)
+app.mount('#app')
+  
+// エラーハンドリング
+app.config.errorHandler = () => {
+  VueRouter.replace({ name: 'InternalServerError' })
+}

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -3,6 +3,7 @@ import HomePage from "../components/pages/HomePage.vue";
 import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
 import NotFoundError from '../components/pages/error/NotFound.vue';
+import InternalServerError from '../components/pages/error/InternalServerError.vue';
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
 import { authLoginMethods } from '../../mixins/auth.js'
 import { store } from '../../store/index.js'
@@ -23,6 +24,11 @@ const routes = [
     path: "/login",
     name: "Login",
     component: LoginPage,
+  },
+  {
+    path: '/error',
+    name: 'InternalServerError',
+    component: InternalServerError,
   },
   // 上から順にマッチするものを探すため一番下に記述
   {

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import HomePage from "../components/pages/HomePage.vue";
 import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
+import NotFoundError from '../components/pages/error/NotFound.vue';
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
 import { authLoginMethods } from '../../mixins/auth.js'
 import { store } from '../../store/index.js'
@@ -22,6 +23,12 @@ const routes = [
     path: "/login",
     name: "Login",
     component: LoginPage,
+  },
+  // 上から順にマッチするものを探すため一番下に記述
+  {
+    path: "/:catchAll(.*)",
+    name: 'NotFoundError',
+    component: NotFoundError,
   },
 ];
 


### PR DESCRIPTION
## 概要
エラーが起こったときに表示するページを作成した。
また実際にエラーが起こった際にページを表示できるようにした。
　close #44  

## やったこと
* 存在しないURLにアクセスし際に表示するページを作成した
  *  404 NotFoundとして画面に表示
  * どのパスにもマッチしなかった場合このルーティングが行われるように実装
* Vue.js側で何かしらの例外的なエラーを拾った場合に表示するページを作成
  * 500 INternal Server Errorとして画面に表示

## 確認項目
- [x] ログインしたのちにルーティングに登録されていないURLにアクセスして404ページが表示されるか
- [x] throw new.Errorなどでエラーを発生させると500エラーのページが表示されるか

## その他
未認証時は登録されていないURLにアクセスした場合は/loginに飛ばされログインするようにと言ったトースターが出力される