### PR TITLE
投稿用のフォームをモーダルとして表示させる

### DIFF
--- a/front/src/components/HeaderBar/HeaderBar.vue
+++ b/front/src/components/HeaderBar/HeaderBar.vue
@@ -7,8 +7,8 @@
       <div class="mr-6 md:mr-10">
         <HeaderHome />
         <HeaderSerch />
-        <HeaderNotification />
         <HeaderMessage />
+        <HeaderNotification />
       </div>
       <div class="flex-shrink-0 flex hover:bg-blue-00 rounded-full mr-2">
         <HeaderUserinfo />

--- a/front/src/components/HeaderBar/HeaderHome.vue
+++ b/front/src/components/HeaderBar/HeaderHome.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link to="/home" class="inline-block mt-0 hover: mr-4">
-    <svg class="md:mr-4 h-5 w-5 md:h-6 md:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
+    <svg class="md:mr-4 h-5 w-5 md:h-7 md:w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"></path></svg>
   </router-link>
 </template>
 

--- a/front/src/components/HeaderBar/HeaderMessage.vue
+++ b/front/src/components/HeaderBar/HeaderMessage.vue
@@ -1,7 +1,7 @@
 <template>
-  <a href="#responsive-header" class="inline-block mt-0 hover:">
-        <svg class="h-5 w-5 md:h-6 md:w-6 group-hover:opacity-60" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
-      </a>
+  <a href="#responsive-header" class="inline-block mt-0 hover: mr-4">
+    <svg class="md:mr-4 h-5 w-5 md:h-7 md:w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
+  </a>
 </template>
 
 <script>

--- a/front/src/components/HeaderBar/HeaderNotification.vue
+++ b/front/src/components/HeaderBar/HeaderNotification.vue
@@ -1,12 +1,34 @@
 <template>
-  <a href="#responsive-header" class="inline-block mt-0  hover: mr-4">
-    <svg class="md:mr-4 h-5 w-5 md:h-6 md:w-6 group-hover:opacity-60" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
-  </a>
+    <div class="inline-block cursor-pointer" @click="showPostFormModal">
+    <svg id="postform" class="md:mr-4 h-5 w-5 md:h-7 md:w-7 hover:" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg> 
+      <PostFormModal />
+    </div>
 </template>
 
 <script>
+  import PostFormModal from '../../components/PostForm/PostFormModal.vue' 
+  import silent_refresh_method from '../../../plugins/silent-refresh-token.js'
 export default {
-  
+  components: {
+    PostFormModal
+  },
+  data() {
+    return {
+      showModalJudge: false  
+    }
+  },
+  methods: {
+    async showPostFormModal(e) {      
+      console.log(e.path[0].id)
+      // モーダル内をクリックした際は何もしない
+      if (e.path[0].id === 'postform' || e.path[0].id === 'modal-base') {
+        this.showModalJudge = !this.showModalJudge
+        this.$store.dispatch('getPostFormModal',  this.showModalJudge )
+      }
+
+      await silent_refresh_method();
+    }
+  }
 }
 </script>
 

--- a/front/src/components/HeaderBar/HeaderSerch.vue
+++ b/front/src/components/HeaderBar/HeaderSerch.vue
@@ -1,6 +1,6 @@
 <template>
   <a href="#responsive-header" class="inline-block mt-0 hover: mr-4">
-    <svg class="md:mr-4 h-5 w-5 md:h-6 md:w-6 group-hover:opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+    <svg class="md:mr-4 h-5 w-5 md:h-7 md:w-7 group-hover:opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
   </a>
 </template>
 

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="isVisible">
     <div id="modal-base" class="fixed -inset-0 bg-black bg-opacity-5 flex flex-col justify-center" style=" background-color: rgba(0,0,0,.5);" ></div>
     <div class="fixed top-1/2 left-1/2 bg-white flex flex-col justify-center w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
       <textarea class="caret-slate-500 border-b resize-none outline-none" placeholder="投稿内容を入力" name="" cols="20" rows="10" maxlength="400"></textarea>
@@ -9,3 +9,13 @@
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  computed: {
+    isVisible() {
+      return this.$store.getters.postFormModal
+    } 
+  }
+}
+</script>

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <div id="modal-base" class="fixed -inset-0 bg-black bg-opacity-5 flex flex-col justify-center" style=" background-color: rgba(0,0,0,.5);" ></div>
+    <div class="fixed top-1/2 left-1/2 bg-white flex flex-col justify-center w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
+      <textarea class="caret-slate-500 border-b resize-none outline-none" placeholder="投稿内容を入力" name="" cols="20" rows="10" maxlength="400"></textarea>
+      <div class="text-right py-4">
+        <span class="py-2 px-5 bg-blue-400 text-white rounded-full text-sm">投稿</span>  
+      </div>
+    </div>
+  </div>
+</template>

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -15,10 +15,14 @@ export const store = createStore({
         message: null,
         color: 'bg-red-500',
         timeout: 4000
-      }
+      },
+      postFormModal: {
+        isVisible: false
+      },
     }
   },
   mutations: {
+  // ユーザー認証
     setCurrentUser (state, payload) {
     state.user.current = payload
     },
@@ -31,11 +35,17 @@ export const store = createStore({
     setAuthPayload (state, payload) {
       state.auth.payload = payload
     },
+  // グローバルトースター
     setToast (state, payload) {
       state.toast = payload
+    },
+  // 投稿用フォーム表示切り替え
+    setPostFormModal(state, payload) {
+      state.postFormModal.isVisible = payload
     }
   },
   actions: {
+  // ユーザー認証
     getCurrentUser ({ commit }, user) {
       commit('setCurrentUser', user)
     },
@@ -50,13 +60,19 @@ export const store = createStore({
       jwtPayload = jwtPayload || {}
       commit('setAuthPayload', jwtPayload)
     },
+  // グローバルトースター
     getToast({ commit }, { message, color, timeout }) {
       color = color || 'bg-red-500'
       timeout = timeout || 4000
       commit('setToast', { message, color, timeout})
+    },
+  // 投稿用フォームモーダル表示切り替え
+    getPostFormModal({ commit }, postModalPayload) {
+        commit('setPostFormModal', postModalPayload)
     }
   },
   getters: {
+  // ユーザー認証情報
     auth_token (state) {
       return  state.auth.token
     },
@@ -68,6 +84,10 @@ export const store = createStore({
     },
     current_user (state) {
       return  state.user.current || {}
+    },
+  // 投稿フォームモーダル
+    postFormModal(state) {
+      return state.postFormModal.isVisible
     }
   }
 })


### PR DESCRIPTION
## 概要
投稿をする際の内容を記載するフォームを作成した。
フォーム自体はモーダルとして表示、非表示させるように実装した
画面のみ作成したため機能はまだない

close #47  

## やったこと
* ヘッダーにあるボタンのレイアウトを修正
  * 投稿用のボタンを追加
  * 各ボタンの位置とサイズを調整
* 投稿内容を記載できるモーダルをコンポーネントとして追加
* 投稿用ボタンを押した際にモーダルが表示または非表示となるように実装
  *  投稿用ボタンを押下した際にモーダルが出現する。
  * モーダルが出現している状態でモーダルの外側を押下するとモーダルが非表示となる。
* 画面遷移をしないためサイレントリフレッシュが動作しなかったためインポートし、サイレントリフレッシュが走るようにした。
  * セッションの有効期限が切れている際に/login画面に戻りトースターが出力される。 
## 確認項目
- [x] モーダルの表示非表示うまく行えているか。
- [x] 意図したレイアウトのモーダルが出現しているか。
- [x] モーダルを表示、非表示した際にもサイレントリフレッシュがはしりログイン状態を管理できているか。

## その他
投稿用のAPIを作成し、つなぎ合わせる