### PR TITLE
Feature/connect post api

### DIFF
--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -7,9 +7,9 @@ class PostsController < ApplicationController
     if post.save
       render json: post
     else
-      if post.errors === ["is too long (maximum is 400 characters)"]
+      if post.errors["body"] === ["is too long (maximum is 400 characters)"]
         render json: { message: '400字以内で入力してください', data: post.errors["body"]}, status:400
-      elsif post.errors === ["can't be blank"]
+      elsif post.errors["body"] === ["can't be blank"]
         render json: { message: '文字を入力してください', data: post.errors["body"] }, status:400    
       else 
         render json: { message: '投稿元のユーザーが見つかりませんでした', data: post.errors }, status: 404

--- a/front/src/components/HeaderBar/HeaderNotification.vue
+++ b/front/src/components/HeaderBar/HeaderNotification.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="inline-block cursor-pointer" @click="showPostFormModal">
-    <svg id="postform" class="md:mr-4 h-5 w-5 md:h-7 md:w-7 hover:" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg> 
-      <PostFormModal />
+    <svg id="postform" class="md:mr-4 h-5 w-5 md:h-7 md:w-7 hover:" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path id="postform-icon-path" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg> 
+      <PostFormModal @closeFormModal="postedCloseModal" />
     </div>
 </template>
 
@@ -14,19 +14,22 @@ export default {
   },
   data() {
     return {
-      showModalJudge: false  
+      showModalJudge: false
     }
   },
   methods: {
-    async showPostFormModal(e) {      
-      console.log(e.path[0].id)
+    async showPostFormModal(e) {
       // モーダル内をクリックした際は何もしない
-      if (e.path[0].id === 'postform' || e.path[0].id === 'modal-base') {
+      if (e.target.id === 'postform' || e.target.id === 'modal-base' || e.target.id === 'postform-icon-path') {
         this.showModalJudge = !this.showModalJudge
         this.$store.dispatch('getPostFormModal',  this.showModalJudge )
       }
-
       await silent_refresh_method();
+    },
+    // 投稿後にモーダルを閉じる
+    postedCloseModal(params) {
+      this.showModalJudge = params
+      this.$store.dispatch('getPostFormModal',  this.showModalJudge )
     }
   }
 }

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -5,7 +5,7 @@
       <textarea 
       v-model="postContent.body" 
       class="caret-slate-500 border-b resize-none outline-none" 
-      placeholder="投稿内容を入力" cols="20" rows="10"
+      placeholder="投稿内容を入力" cols="20" rows="10" maxlength="400"
       >
       </textarea>
       <div class="text-right py-3">

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -2,9 +2,20 @@
   <div v-if="isVisible">
     <div id="modal-base" class="fixed -inset-0 bg-black bg-opacity-5 flex flex-col justify-center" style=" background-color: rgba(0,0,0,.5);" ></div>
     <div class="fixed top-1/2 left-1/2 bg-white flex flex-col justify-center w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
-      <textarea class="caret-slate-500 border-b resize-none outline-none" placeholder="投稿内容を入力" name="" cols="20" rows="10" maxlength="400"></textarea>
-      <div class="text-right py-4">
-        <span class="py-2 px-5 bg-blue-400 text-white rounded-full text-sm">投稿</span>  
+      <textarea 
+      v-model="postContent.body" 
+      class="caret-slate-500 border-b resize-none outline-none" 
+      placeholder="投稿内容を入力" cols="20" rows="10"
+      >
+    </textarea>
+      <div class="text-right py-3">
+        <button @click="submitPostContent" 
+        :disabled="buttonDisabled" 
+        class="py-2 px-6 text-white rounded-full text-sm"
+        :class="{ 'bg-blue-300': buttonDisabled == true, 'bg-blue-400': buttonDisabled == false }"
+        >
+        投稿
+      </button>  
       </div>
     </div>
   </div>
@@ -12,10 +23,45 @@
 
 <script>
 export default {
+  data() {
+    return {
+      postContent: {
+        body: '',
+        user_id: this.$store.getters.current_user.id
+      },
+      buttonDisabled: false
+    }
+  },
+  methods: {
+    async submitPostContent() {
+      await this.axios.post('/posts', this.postContent)
+        .then( response => this.postContentSuccess(response))
+        .catch( error => this.postContentError(error))
+      },
+      postContentSuccess() {
+        this.postContent.body = ''
+        this.$emit("closeFormModal", false)
+      },
+      postContentError(error) {
+        const message = error.response.data.message
+        this.$store.dispatch('getToast', { message })
+      }
+  },
   computed: {
     isVisible() {
       return this.$store.getters.postFormModal
-    } 
+    }, 
+  },
+  updated() {
+    if (this.postContent.body === '') {
+      this.buttonDisabled = true
+    }
+    else if (this.postContent.body.length > 400) {
+      this.buttonDisabled = true
+    }
+    else {
+      this.buttonDisabled = false
+    }
   }
 }
 </script>

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -7,7 +7,7 @@
       class="caret-slate-500 border-b resize-none outline-none" 
       placeholder="投稿内容を入力" cols="20" rows="10"
       >
-    </textarea>
+      </textarea>
       <div class="text-right py-3">
         <button @click="submitPostContent" 
         :disabled="buttonDisabled" 


### PR DESCRIPTION
## 概要　
投稿用のAPIとフロント側の繋ぎ込みを行った
APIに対してpostメソッドでリクエスト(/posts)を送信し投稿を作成できるように実装
投稿がうまくできなかった際は例外としてトースターを出力するようにした。

close #52 

## やったこと
- 投稿内容がない場合や文字数が多すぎる(バリデーションを通過しない)場合、投稿ボタンをグレーアウトし投稿ができないように実装
- 投稿用のAPIへpostメソッドを`/posts`送信し投稿内容を保存できるようにした。
  -  送信する際に投稿内容であるbodyと投稿ユーザーを識別するuser_idを渡して投稿する
  - 投稿に成功した際は投稿用のフォームモーダルが閉じる
- 投稿に失敗した際に例外処理を実装
  -  文字数が400字以上である、または文字が入力されていない場合など何らかの影響でrailsが例外を返した場合、グローバルトースターとしてメッセージを出力する
- 投稿用のフォームモーダルの切り替えがスムーズに行えるように修正を加えた
- 投稿関連の軽微な記載修正

## 確認観点
- [x] バリデーションを通らない値を送信しようとした場合、投稿ボタンがグレーアウトし押せないようになっているか
- [x] 投稿ボタンを押した際にデータベースに投稿内容が保存されているか
- [x] 投稿ボタンを押して失敗した際にエラー内容が出力されるか
- [x] 投稿に成功した場合モーダルが自動で閉じるようになっているか

## その他
投稿一覧を作成し、閲覧が可能になった際
新規で投稿した内容が投稿一覧に反映される処理を追加する必要がある