### PR TITLE
Feature/create post list timeline

### DIFF
--- a/front/plugins/post-list-fetch.js
+++ b/front/plugins/post-list-fetch.js
@@ -1,0 +1,10 @@
+import axios from "axios"
+import { store } from '../store/index.js'
+
+const post_list_fetch = async () => {
+  await axios.get('/posts')
+    .then(response =>  store.dispatch('getPostList', response.data))
+    .catch(error => console.log(error))
+}
+
+export default post_list_fetch

--- a/front/plugins/post-list-fetch.js
+++ b/front/plugins/post-list-fetch.js
@@ -3,7 +3,7 @@ import { store } from '../store/index.js'
 
 const post_list_fetch = async () => {
   await axios.get('/posts')
-    .then(response =>  store.dispatch('getPostList', response.data))
+    .then(response => store.dispatch('getPostList', response.data))
     .catch(error => console.log(error))
 }
 

--- a/front/src/components/HeaderBar/HeaderUserinfo.vue
+++ b/front/src/components/HeaderBar/HeaderUserinfo.vue
@@ -8,12 +8,12 @@
         </div>
         <div class="ml-3 hidden md:block">
           <p class="text-sm leading-6 font-medium">
-            筋トレ 太郎
+            {{ currentUserInfo.name }}
           </p>
         </div>
       </div>
     </a>
-    <div class="absolute top-11 p-5 shadow-lg text-sm bg-white" v-if="settingDrower">
+    <div class="absolute top-11 -left-5 min-w-max p-5 shadow-lg text-sm bg-white" v-if="settingDrower">
       <div class="mb-2 cursor-pointer">設定</div>
       <div class="cursor-pointer" @click="Logout">ログアウト</div>
     </div>
@@ -38,6 +38,11 @@ export default {
       this.$router.push('/login')
     }
   },
+  computed: {
+    currentUserInfo() {
+      return this.$store.getters.current_user
+    }
+  },  
   mounted() {
     const $this = this
     document.addEventListener("click", function (e) {
@@ -45,7 +50,7 @@ export default {
       if (target === null) {
         $this.settingDrower = false
       }
-    });
+    })
   }
 }
 </script>

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -22,6 +22,7 @@
 </template>
 
 <script>
+import post_list_fetch from '../../../plugins/post-list-fetch.js'
 export default {
   data() {
     return {
@@ -40,7 +41,8 @@ export default {
       },
       postContentSuccess() {
         this.postContent.body = ''
-        this.$emit("closeFormModal", false)
+        this.$emit("closeFormModal", false)  
+        post_list_fetch()
       },
       postContentError(error) {
         const message = error.response.data.message

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -35,7 +35,6 @@
 import PostUserinfo from './PostUserinfo.vue'
 import PostReply from './PostReply.vue'
 import PostFavorite from './PostFavorite.vue'
-import post_list_fetch  from '../../../plugins/post-list-fetch.js'
 export default {
   components: {
     PostUserinfo,
@@ -43,12 +42,9 @@ export default {
     PostFavorite
   },
   computed: {
-    showPostList(){
+    showPostList() {
       return this.$store.getters.postList
     }
-  },
-  async mounted() {
-    await post_list_fetch()
   }
 }
 </script>

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -6,7 +6,7 @@
         <PostUserinfo />
         <div class="ml-3">
           <span class="text-sm leading-5 ml-2 font-medium text-gray-400">
-            8月1日
+            {{ postedTime(post.created_at)}}
           </span>
         </div>
       </div>
@@ -40,6 +40,13 @@ export default {
     PostUserinfo,
     PostReply,
     PostFavorite
+  },
+  methods: {
+    postedTime(time) {
+      const postedMonth = time.slice(5, 7)
+      const postedDate = time.slice(8, 10)
+      return postedMonth + '月' + postedDate + '日'
+    }
   },
   computed: {
     showPostList() {

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -1,5 +1,5 @@
 <template>
-<div>
+<div v-for="post in showPostList" :key="post.id">
   <div class="flex flex-shrink-0 p-4 pb-0">
     <a href="#" class="flex-shrink-0 group block">
       <div class="flex items-center">
@@ -12,11 +12,9 @@
       </div>
     </a>
   </div>
-
   <div class="pl-16">
     <p class="text-base width-auto font-medium  flex-shrink">
-      テキストが入ります
-      テキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入りますテキストが入ります
+      {{ post.body }}
       <span class="text-blue-400"># リンクが入ります</span>
     </p>
 
@@ -37,11 +35,20 @@
 import PostUserinfo from './PostUserinfo.vue'
 import PostReply from './PostReply.vue'
 import PostFavorite from './PostFavorite.vue'
+import post_list_fetch  from '../../../plugins/post-list-fetch.js'
 export default {
   components: {
     PostUserinfo,
     PostReply,
     PostFavorite
+  },
+  computed: {
+    showPostList(){
+      return this.$store.getters.postList
+    }
+  },
+  async mounted() {
+    await post_list_fetch()
   }
 }
 </script>

--- a/front/src/components/PostList/PostUserinfo.vue
+++ b/front/src/components/PostList/PostUserinfo.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="ml-3">
       <span class="text-sm leading-6 font-medium ">
-        筋トレ 太郎 
+        {{ currentUserInfo.name }}
       </span>
     </div>
   </a>
@@ -13,6 +13,10 @@
 
 <script>
 export default {
-  
+  computed: {
+    currentUserInfo() {
+      return this.$store.getters.current_user
+    }
+  },
 }
 </script>

--- a/front/src/components/pages/HomePage.vue
+++ b/front/src/components/pages/HomePage.vue
@@ -17,10 +17,14 @@
 <script>
 import Post from '../PostList/Post.vue'
 import HeaderBar from '../HeaderBar/HeaderBar.vue'
+import post_list_fetch from '../../../plugins/post-list-fetch.js'
 export default {
   components: {
     Post,
     HeaderBar
+  },
+  async mounted() {
+    await post_list_fetch()
   }
 }
 </script>

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -19,7 +19,7 @@ export const store = createStore({
       postFormModal: {
         isVisible: false
       },
-      postList: null
+      postList: []
     }
   },
   mutations: {
@@ -100,7 +100,14 @@ export const store = createStore({
     },
   // 投稿一覧
     postList(state) {
-      return state.postList
+      // 投稿リストを日付順に並び替える
+      let postListByDate =  Object.keys(state.postList).map(key => {
+        return state.postList[key];
+      })
+      postListByDate.sort(function (a, b) {
+        return (a.created_at > b.created_at) ? -1 : 1;  //オブジェクト昇順ソート
+      })
+      return postListByDate
     }
   }
 })

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -19,6 +19,7 @@ export const store = createStore({
       postFormModal: {
         isVisible: false
       },
+      postList: null
     }
   },
   mutations: {
@@ -42,6 +43,10 @@ export const store = createStore({
   // 投稿用フォーム表示切り替え
     setPostFormModal(state, payload) {
       state.postFormModal.isVisible = payload
+    },
+  // 投稿一覧を取得
+    setPostList(state, payload) {
+      state.postList = payload
     }
   },
   actions: {
@@ -68,7 +73,11 @@ export const store = createStore({
     },
   // 投稿用フォームモーダル表示切り替え
     getPostFormModal({ commit }, postModalPayload) {
-        commit('setPostFormModal', postModalPayload)
+      commit('setPostFormModal', postModalPayload)
+    },
+  // 投稿一覧を取得
+    getPostList({ commit }, postList) {
+      commit('setPostList', postList)
     }
   },
   getters: {
@@ -88,6 +97,10 @@ export const store = createStore({
   // 投稿フォームモーダル
     postFormModal(state) {
       return state.postFormModal.isVisible
+    },
+  // 投稿一覧
+    postList(state) {
+      return state.postList
     }
   }
 })


### PR DESCRIPTION
## 概要
投稿してきた内容を一覧で表示できるようにした。
投稿した内容と時間ユーザー名なども合わせて表示できるように修正
また新規投稿した際にも新規投稿が瞬時に表示されるように実装した
タイムラインに関しては時間が新しいものが上に来るようにした

close #58 #57 #49 

## やったこと
-  投稿用APIを叩いて全ての投稿を取得し、一覧に表示
  - 上に新しい投稿が来るように実装した
  - 投稿した時間を〇〇月××日となるように表示
  - 投稿の右上のユーザー情報にログインユーザーの名前を表示
  - 新規投稿した際にリロードせずに一覧に投稿が反映されるように実装

## 確認項目
- [x] 新しい投稿が上になるようにして一覧に投稿が表示されているか
- [x] 投稿日時の表示は間違っていないか、表示されているか
- [x] ユーザー情報の表示は間違っていないか、表示されているか
- [x] 新規投稿をした際、即座に一覧に反映されているか

## その他
ユーザー情報のボタンを押した時ユーザー個人ページに遷移するようにする
表示されている投稿を削除、更新できるようする
