### PR TITLE
投稿一覧から特定の投稿を更新・削除できるように修正

### DIFF
--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -29,8 +29,17 @@ class PostsController < ApplicationController
 
   def update
     update_post = Post.find(params[:id])
-    update_post.update(post_params)
-    render json: { message: "投稿内容の更新に成功しました", data: update_post }, status:201
+    if update_post.update(post_params)
+      render json: { message: '投稿内容の更新に成功しました', data: update_post }, status:201
+    else 
+      if update_post.errors["body"] === ["is too long (maximum is 400 characters)"]
+        render json: { message: '400字以内で入力してください', data: update_post.errors["body"] }, status:400
+      elsif update_post.errors["body"] === ["can't be blank"]
+        render json: { message: '文字を入力してください', data: update_post.errors["body"] }, status:400    
+      else 
+        render json: { message: '投稿が見つかりませんでした', data: update_post.errors["body"] }, status: 404
+      end
+    end
   end
 
   def destroy

--- a/front/src/components/AppToaster.vue
+++ b/front/src/components/AppToaster.vue
@@ -2,7 +2,7 @@
   <div
    v-if="setToaster"
    v-bind:class = this.toast.color
-   class=" rounded-md z-40 fixed top-9 right-0 left-0 mx-auto w-1/2"
+   class=" rounded-md z-50 fixed top-9 right-0 left-0 mx-auto w-1/2"
    >
     <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
       <div class="flex flex-wrap items-center justify-between">

--- a/front/src/components/PostForm/UpdatePostForm.vue
+++ b/front/src/components/PostForm/UpdatePostForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="showUpdateArea">
     <div id="modal-base" class="fixed -inset-0 z-30 bg-black bg-opacity-5 flex flex-col justify-center" style=" background-color: rgba(0,0,0,.5);"></div>
-    <div class="fixed top-1/2 left-1/2 bg-white flex flex-col justify-center z-40 w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
+    <div class="post-update-modal fixed top-1/2 left-1/2 bg-white flex flex-col justify-center z-40 w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
       <textarea 
         v-model="textareaContent"
         class="caret-slate-500 resize-none outline-none w-full border-b" id="updateForm"

--- a/front/src/components/PostForm/UpdatePostForm.vue
+++ b/front/src/components/PostForm/UpdatePostForm.vue
@@ -1,0 +1,53 @@
+<template>
+  <div v-if="showUpdateArea">
+    <div id="modal-base" class="fixed -inset-0 z-30 bg-black bg-opacity-5 flex flex-col justify-center" style=" background-color: rgba(0,0,0,.5);"></div>
+    <div class="fixed top-1/2 left-1/2 bg-white flex flex-col justify-center z-40 w-3/5 h-auto rounded-xl p-8 pb-0 -translate-y-2/4 -translate-x-2/4">
+      <textarea 
+        v-model="textareaContent"
+        class="caret-slate-500 resize-none outline-none w-full border-b" id="updateForm"
+        placeholder="変更内容を入力" cols="20" rows="10" maxlength="400">
+      </textarea>
+      <div class="flex justify-end py-2">
+        <button @click="submitPostContent" :disabled="buttonDisabled" class="py-2 px-6  text-white rounded-full text-sm"
+        :class="{ 'bg-blue-300': buttonDisabled == true, 'bg-blue-400': buttonDisabled == false }">
+        更新
+        </button>
+    </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    showUpdateArea: {
+      type: Boolean
+    },
+    updatePostContent: {
+      type: Object
+    }
+  },
+  data() {
+    return {
+      textareaContent: '',
+      buttonDisabled: false
+    }
+  },
+  watch: {
+    updatePostContent: function (newVal) {
+      this.textareaContent = newVal.body  
+    }
+  },
+  updated() {
+    if (this.textareaContent === '') {
+      this.buttonDisabled = true
+    }
+    else if (this.textareaContent.length > 400) {
+      this.buttonDisabled = true
+    }
+    else {
+      this.buttonDisabled = false
+    }
+  }
+}
+</script>

--- a/front/src/components/PostForm/UpdatePostForm.vue
+++ b/front/src/components/PostForm/UpdatePostForm.vue
@@ -8,7 +8,7 @@
         placeholder="変更内容を入力" cols="20" rows="10" maxlength="400">
       </textarea>
       <div class="flex justify-end py-2">
-        <button @click="submitPostContent" :disabled="buttonDisabled" class="py-2 px-6  text-white rounded-full text-sm"
+        <button @click="submitPostUpdate" :disabled="buttonDisabled" class="py-2 px-6  text-white rounded-full text-sm"
         :class="{ 'bg-blue-300': buttonDisabled == true, 'bg-blue-400': buttonDisabled == false }">
         更新
         </button>
@@ -31,6 +31,30 @@ export default {
     return {
       textareaContent: '',
       buttonDisabled: false
+    }
+  },
+  methods: {
+    async submitPostUpdate() {
+      await this.axios.patch(`/posts/${this.updatePostContent.id}`, {
+        body: this.textareaContent,
+        user_id: this.$store.getters.current_user.id
+      })
+        .then(response => this.postUpdateSuccess(response.data))
+        .catch(error => console.log(error))
+    },
+    postUpdateSuccess(response) {
+      this.$emit('closeUpdateFormModal', false)
+      console.log(response)
+      const targetPost = {
+        body: response.data.body,
+        id: response.data.id,
+        user_id: response.data.user_id
+      }
+      this.$store.dispatch('updatePost', targetPost)
+      const message = '投稿内容を更新しました'
+      const color = 'bg-blue-500'
+      const timeout = 2000
+      this.$store.dispatch('getToast', { message, color, timeout })
     }
   },
   watch: {

--- a/front/src/components/PostForm/UpdatePostForm.vue
+++ b/front/src/components/PostForm/UpdatePostForm.vue
@@ -40,7 +40,11 @@ export default {
         user_id: this.$store.getters.current_user.id
       })
         .then(response => this.postUpdateSuccess(response.data))
-        .catch(error => console.log(error))
+        .catch(error => {
+          const message = error.response.data.message || '投稿が見つかりませんでした'
+          this.$store.dispatch('getToast', { message })
+          console.log(error)
+        })
     },
     postUpdateSuccess(response) {
       this.$emit('closeUpdateFormModal', false)

--- a/front/src/components/PostForm/UpdatePostForm.vue
+++ b/front/src/components/PostForm/UpdatePostForm.vue
@@ -43,12 +43,10 @@ export default {
         .catch(error => {
           const message = error.response.data.message || '投稿が見つかりませんでした'
           this.$store.dispatch('getToast', { message })
-          console.log(error)
         })
     },
     postUpdateSuccess(response) {
       this.$emit('closeUpdateFormModal', false)
-      console.log(response)
       const targetPost = {
         body: response.data.body,
         id: response.data.id,

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -2,28 +2,32 @@
 <div>
   <div v-for="post in showPostList" :key="post.id" :id=post.id>
     <div class="relative flex flex-shrink-0 p-4 pb-0">
-    <a href="#" class="flex-shrink-0 group block">
-      <div class="flex items-center">
-        <PostUserinfo />
+      <a href="#" class="flex-shrink-0 group block">
+        <div class="flex items-center">
+          <PostUserinfo />
+        </div>
+      </a>
+      <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">
+        {{ postedTime(post.created_at)}}
       </div>
-    </a>
-    <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">
-      {{ postedTime(post.created_at)}}
+      <svg @click="showPostDrawer(post.id); selectePostId(post.id)" class="post-drawer-icon w-8 h-8 p-1 my-auto cursor-pointer rounded-full duration-200 hover:bg-black hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z">
+        </path>
+      </svg>
+      <PostDrawer 
+      :showPostDrawer="postDrawerBoolean" 
+      :selectedPostId = "selectedPost" 
+      @showPostUpdateArea = "postUpdateArea = $event, showPostDrawer()"
+      v-if="post.id === selectedPost" 
+      />
     </div>
-    <svg @click="showPostDrawer(post.id); selectePostId(post.id)" class="post-drawer-icon w-8 h-8 p-1 my-auto cursor-pointer rounded-full duration-200 hover:bg-black hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-        d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z">
-      </path>
-    </svg>
-    <PostDrawer :showPostDrawer="postDrawerBoolean" :selectedPostId = "selectedPost" v-if="post.id === selectedPost" />
-  </div>
-  <div class="pl-16">
-    <p class="text-base width-auto font-medium  flex-shrink">
-      {{ post.body }}
-      <span class="text-blue-400"># リンクが入ります</span>
-    </p>
-    <div class="flex">
-      <div class="w-full">
+    <div class="pl-16">
+      <p class="text-base width-auto font-medium  flex-shrink break-all pr-4">
+        {{ post.body }}
+      </p>
+      <div class="flex">
+        <div class="w-full">
           <div class="flex justify-end items-center">
             <PostReply />
             <PostFavorite />
@@ -33,6 +37,11 @@
     </div>
     <hr class="border-gray-600">
   </div>
+  <UpdatePostForm 
+  :showUpdateArea = postUpdateArea
+  :updatePostContent = identifyPostUpdate
+  />
+  {{ identifyPostUpdate }}
 </div>
 </template>
 
@@ -41,17 +50,21 @@ import PostUserinfo from './PostUserinfo.vue'
 import PostReply from './PostReply.vue'
 import PostFavorite from './PostFavorite.vue'
 import PostDrawer from './PostDrawer.vue'
+import UpdatePostForm from '../PostForm/UpdatePostForm.vue'
 export default {
   components: {
     PostUserinfo,
     PostReply,
     PostFavorite,
-    PostDrawer
+    PostDrawer,
+    UpdatePostForm
   },
   data() {
     return {
       postDrawerBoolean: false,
-      selectedPost: null
+      selectedPost: null,
+      postUpdateArea: false,
+      identifyPostUpdate: null
     }
   },
   methods: {
@@ -70,9 +83,22 @@ export default {
   computed: {
     showPostList() {
       return this.$store.getters.postList
+    },
+  },
+  watch: {
+    postUpdateArea: function (newVal) {
+      if (newVal === true) {
+        for (let i = 0; i < this.showPostList.length; i++){
+          if (this.showPostList[i].id === this.selectedPost) {
+            this.identifyPostUpdate = this.showPostList[i]
+            break
+          }
+        }
+      }
     }
   },
   mounted() { 
+    // ドロワー表示中に画面をクリックした際にドロワーを閉じる
     const $this = this
     document.addEventListener("click", function (e) {
       const target = (e.target).closest(".post-drawer-icon")

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -1,33 +1,38 @@
 <template>
-<div v-for="post in showPostList" :key="post.id">
-  <div class="flex flex-shrink-0 p-4 pb-0">
+<div>
+  <div v-for="post in showPostList" :key="post.id" :id=post.id>
+    <div class="relative flex flex-shrink-0 p-4 pb-0">
     <a href="#" class="flex-shrink-0 group block">
       <div class="flex items-center">
         <PostUserinfo />
-        <div class="ml-3">
-          <span class="text-sm leading-5 ml-2 font-medium text-gray-400">
-            {{ postedTime(post.created_at)}}
-          </span>
-        </div>
       </div>
     </a>
+    <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">
+      {{ postedTime(post.created_at)}}
+    </div>
+    <svg @click="showPostDrawer(post.id); selectePostId(post.id)" class="post-drawer-icon w-8 h-8 p-1 my-auto cursor-pointer rounded-full duration-200 hover:bg-black hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z">
+      </path>
+    </svg>
+    <PostDrawer :showPostDrawer="postDrawerBoolean" :selectedPostId = "selectedPost" v-if="post.id === selectedPost" />
   </div>
   <div class="pl-16">
     <p class="text-base width-auto font-medium  flex-shrink">
       {{ post.body }}
       <span class="text-blue-400"># リンクが入ります</span>
     </p>
-
     <div class="flex">
       <div class="w-full">
-        <div class="flex justify-end items-center">
-          <PostReply />
-          <PostFavorite />
+          <div class="flex justify-end items-center">
+            <PostReply />
+            <PostFavorite />
+          </div>
         </div>
-      </div>
-    </div>  
+      </div>  
+    </div>
+    <hr class="border-gray-600">
   </div>
-  <hr class="border-gray-600">
 </div>
 </template>
 
@@ -35,23 +40,46 @@
 import PostUserinfo from './PostUserinfo.vue'
 import PostReply from './PostReply.vue'
 import PostFavorite from './PostFavorite.vue'
+import PostDrawer from './PostDrawer.vue'
 export default {
   components: {
     PostUserinfo,
     PostReply,
-    PostFavorite
+    PostFavorite,
+    PostDrawer
+  },
+  data() {
+    return {
+      postDrawerBoolean: false,
+      selectedPost: null
+    }
   },
   methods: {
     postedTime(time) {
       const postedMonth = time.slice(5, 7)
       const postedDate = time.slice(8, 10)
       return postedMonth + '月' + postedDate + '日'
+    },
+    showPostDrawer() {
+      this.postDrawerBoolean = !this.postDrawerBoolean
+    },
+    selectePostId(id) {
+      this.selectedPost = id
     }
   },
   computed: {
     showPostList() {
       return this.$store.getters.postList
     }
+  },
+  mounted() { 
+    const $this = this
+    document.addEventListener("click", function (e) {
+      const target = (e.target).closest(".post-drawer-icon")
+      if (target === null && $this.postDrawerBoolean) {
+        $this.showPostDrawer()
+      }
+    })
   }
 }
 </script>

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -40,6 +40,7 @@
   <UpdatePostForm 
   :showUpdateArea = postUpdateArea
   :updatePostContent = identifyPostUpdate
+  @closeUpdateFormModal = "postUpdateArea = $event" 
   />
 </div>
 </template>

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -41,7 +41,6 @@
   :showUpdateArea = postUpdateArea
   :updatePostContent = identifyPostUpdate
   />
-  {{ identifyPostUpdate }}
 </div>
 </template>
 
@@ -101,9 +100,15 @@ export default {
     // ドロワー表示中に画面をクリックした際にドロワーを閉じる
     const $this = this
     document.addEventListener("click", function (e) {
-      const target = (e.target).closest(".post-drawer-icon")
-      if (target === null && $this.postDrawerBoolean) {
+      const targetPostDrawer = (e.target).closest(".post-drawer-icon")
+      if (targetPostDrawer === null && $this.postDrawerBoolean) {
         $this.showPostDrawer()
+      }
+    // 投稿更新用のモーダルを閉じる
+      const targetPostUpdateArea = (e.target).closest(".post-update-modal")
+      const postUpdateButton = (e.target).closest(".post-update-button")
+      if (targetPostUpdateArea === null && $this.postUpdateArea && !postUpdateButton) {
+        $this.postUpdateArea = false
       }
     })
   }

--- a/front/src/components/PostList/PostDrawer.vue
+++ b/front/src/components/PostList/PostDrawer.vue
@@ -20,7 +20,14 @@ export default {
       console.log('update')
     },
     postDelete() {
-      console.log('delete')
+      if (confirm('本当に削除しますか？')) {
+        this.axios.delete(`/posts/${this.selectedPostId}`)
+          .then(() => this.$store.dispatch('deletePost', this.selectedPostId))
+          .catch(() => {
+            const message = '投稿を削除できませんでした'
+            this.$store.dispatch('getToast', {message})
+          })
+      }
     }
   }
 }

--- a/front/src/components/PostList/PostDrawer.vue
+++ b/front/src/components/PostList/PostDrawer.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="absolute top-14 right-0 min-w-max p-5 shadow-lg text-sm bg-white" v-if="showPostDrawer">
+    <div class="mb-2 cursor-pointer" @click="postUpdate">編集</div>
+    <div class="cursor-pointer" @click="postDelete">削除</div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    showPostDrawer: {
+      type: Boolean
+    },
+    selectedPostId: {
+      type: Number
+    }
+  },
+  methods: {
+    postUpdate() {
+      console.log('update')
+    },
+    postDelete() {
+      console.log('delete')
+    }
+  }
+}
+</script>

--- a/front/src/components/PostList/PostDrawer.vue
+++ b/front/src/components/PostList/PostDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute top-14 right-0 min-w-max p-5 shadow-lg text-sm bg-white" v-if="showPostDrawer">
+  <div class="absolute top-14 right-0 min-w-max z-10 p-5 shadow-lg text-sm bg-white" v-if="showPostDrawer">
     <div class="mb-2 cursor-pointer" @click="postUpdate">編集</div>
     <div class="cursor-pointer" @click="postDelete">削除</div>
   </div>
@@ -16,9 +16,6 @@ export default {
     }
   },
   methods: {
-    postUpdate() {
-      console.log('update')
-    },
     postDelete() {
       if (confirm('本当に削除しますか？')) {
         this.axios.delete(`/posts/${this.selectedPostId}`)
@@ -28,6 +25,10 @@ export default {
             this.$store.dispatch('getToast', {message})
           })
       }
+    },
+    postUpdate() {
+      console.log('showupdateArea')
+      this.$emit('showPostUpdateArea', true)
     }
   }
 }

--- a/front/src/components/PostList/PostDrawer.vue
+++ b/front/src/components/PostList/PostDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="absolute top-14 right-0 min-w-max z-10 p-5 shadow-lg text-sm bg-white" v-if="showPostDrawer">
-    <div class="mb-2 cursor-pointer" @click="postUpdate">編集</div>
+    <div class="post-update-button mb-2 cursor-pointer" @click="postUpdate">編集</div>
     <div class="cursor-pointer" @click="postDelete">削除</div>
   </div>
 </template>

--- a/front/src/components/PostList/PostDrawer.vue
+++ b/front/src/components/PostList/PostDrawer.vue
@@ -27,7 +27,6 @@ export default {
       }
     },
     postUpdate() {
-      console.log('showupdateArea')
       this.$emit('showPostUpdateArea', true)
     }
   }

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -44,9 +44,15 @@ export const store = createStore({
     setPostFormModal(state, payload) {
       state.postFormModal.isVisible = payload
     },
-  // 投稿一覧を取得
+  // 投稿に関するメソッド
     setPostList(state, payload) {
       state.postList = payload
+    },
+    deletePost(state, payload) {
+      const deletedPostArray = state.postList.filter(post => {
+        return post.id !== payload
+      })
+      state.postList = deletedPostArray
     }
   },
   actions: {
@@ -75,9 +81,12 @@ export const store = createStore({
     getPostFormModal({ commit }, postModalPayload) {
       commit('setPostFormModal', postModalPayload)
     },
-  // 投稿一覧を取得
+  // 投稿に関するメソッド
     getPostList({ commit }, postList) {
       commit('setPostList', postList)
+    },
+    deletePost({ commit }, selectedPost) {
+      commit('deletePost', selectedPost)
     }
   },
   getters: {

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -53,6 +53,13 @@ export const store = createStore({
         return post.id !== payload
       })
       state.postList = deletedPostArray
+    },
+    updatePost(state, payload) {
+      state.postList.map(post => {
+        if (post.id === payload.id) {
+          post.body = payload.body
+        }
+      })
     }
   },
   actions: {
@@ -87,6 +94,9 @@ export const store = createStore({
     },
     deletePost({ commit }, selectedPost) {
       commit('deletePost', selectedPost)
+    },
+    updatePost({ commit }, updatedPostContent) {
+      commit('updatePost', updatedPostContent)
     }
   },
   getters: {


### PR DESCRIPTION
## 概要
投稿の右上に3点リーダーを追加し、そちらから更新と削除が行えるように実装を行なった。3点リーダをクリックすると編集と削除ボタンがドロワーとして出現する。
修正ボタンを押すと、新規投稿時と同じフォームモーダルが出現し、更新を行える。
削除ボタンを押すと確認のアラートが出現したのち、OKを押下すると削除される。

close #61  
relation #51 

## やったこと
* 投稿の右上に三点リーダを追加し、ドロワーを表示させるように修正
* ドロワーと更新用のモーダルについては枠外を押下すると閉じるように実装
* 投稿を編集する事が出るように修正
  *  編集ボタンを押下した際、新規投稿時に表示するモーダルを表示し、変更内容を入力できるようにした
  * 修正内容をPATCHメソッドで送信し、DBのデータを書き換えるとともに、Vuexのストア内のデータを書き換え表示を変更するようにした
  * 更新が完了した際にはトースターを出現させるようにした
  * 更新に失敗した際にエラー内容を返すことができるようにAPIを修正した
  * 更新に失敗した際にはエラーメッセージを表示させるようにした
* 投稿の削除ができるように修正
  * 削除ボタンを押下した際に投稿が削除される
  * deleteメソッドでDB内のデータを削除し、同時にVuexのストアから削除することで画面上の表示をなくす

## 確認観点
- [x] 3点リーダーを押下した際、ドロワーが表示されるか  
またドロワー外を押下した際にドロワーが閉じるか
- [x] 編集ボタンを押下した際にモーダルが出現し、投稿の更新ができるか  
また更新に成功した際にトースターが出現するか
- [x] 削除ボタンを押下した際に確認アラートが出現し、投稿が削除できるか
- [x] 投稿の更新、削除に失敗した際に適切な内容のエラーメッセージがトースターとして出力されているか

## その他
