### PR TITLE
どのユーザーが投稿した内容のか判別できるように投稿一覧を修正

### DIFF
--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -19,7 +19,14 @@ class PostsController < ApplicationController
 
   def index
     post_all = Post.all
-    render json: post_all
+    add_username_post_all = post_all.map do |post| 
+      posted_user_name = User.find_by(id: post[:user_id]).name
+      { 
+        "id" => post.id, "body" => post.body, "created_at" => post.created_at, "updated_at" => post.updated_at, 
+        "user_id" => post.user_id, "user_name" => posted_user_name
+      }
+    end
+    render json: add_username_post_all
   end
 
   def show

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -4,7 +4,7 @@
     <div class="relative flex flex-shrink-0 p-4 pb-0">
       <a href="#" class="flex-shrink-0 group block">
         <div class="flex items-center">
-          <PostUserinfo />
+          <PostUserinfo :postedUserName="post.user_name" />
         </div>
       </a>
       <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -10,7 +10,7 @@
       <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">
         {{ postedTime(post.created_at)}}
       </div>
-      <svg @click="showPostDrawer(post.id); selectePostId(post.id)" class="post-drawer-icon w-8 h-8 p-1 my-auto cursor-pointer rounded-full duration-200 hover:bg-black hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg v-if="currentUser.id === post.user_id" @click="showPostDrawer(post.id); selectePostId(post.id)" class="post-drawer-icon w-8 h-8 p-1 my-auto cursor-pointer rounded-full duration-200 hover:bg-black hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
           d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z">
         </path>
@@ -64,7 +64,8 @@ export default {
       postDrawerBoolean: false,
       selectedPost: null,
       postUpdateArea: false,
-      identifyPostUpdate: null
+      identifyPostUpdate: null,
+      currentUser: this.$store.getters.current_user
     }
   },
   methods: {

--- a/front/src/components/PostList/PostUserinfo.vue
+++ b/front/src/components/PostList/PostUserinfo.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="ml-3">
       <span class="text-sm leading-6 font-medium ">
-        {{ currentUserInfo.name }}
+        {{ postedUserName }}
       </span>
     </div>
   </a>
@@ -13,10 +13,10 @@
 
 <script>
 export default {
-  computed: {
-    currentUserInfo() {
-      return this.$store.getters.current_user
+  props: {
+    postedUserName: {
+      type:String
     }
-  },
+  }
 }
 </script>


### PR DESCRIPTION
## 概要
どのユーザーが投稿した内容のか判別できるように投稿一覧を修正
投稿したユーザーのユーザー名を投稿一覧に表示し、現在ログインしているユーザーが投稿した内容のみ更新・削除が行えるように修正

close #63 

## やったこと
* 投稿一覧のユーザー名を投稿した人のユーザー名を表示できるようにした
  * 投稿内容を全て取得してくるAPIを叩いた際に投稿内容と投稿ユーザー名を一緒に返すように修正
* 現在ログインしているユーザーの投稿のみ更新・削除ができるようにした
  *  ログインユーザーが投稿したもののみ更新・削除ボタンが出る三点リーダを表示するようにした

## 確認項目
- [x] 投稿ユーザーの名前が正しく表示されているか
- [x] ログインしているユーザーの投稿のみ編集・削除ができるか

## その他
ユーザー別の画像については今後実装していく必要がある