### PR TITLE
ユーザー情報の設定画面と更新機能を追加

### DIFF
--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -1,6 +1,6 @@
 class UserController < ApplicationController
   include UserSessionizeService
-  before_action :sessionize_user
+  before_action :sessionize_user,  except: :create
 
   def index
     render json: current_user.as_json(only: [:id, :name, :email, :created_at])

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -1,6 +1,7 @@
 class UserController < ApplicationController
-  before_action :authenticate_user, except: [:create]
-  
+  include UserSessionizeService
+  before_action :sessionize_user
+
   def index
     render json: current_user.as_json(only: [:id, :name, :email, :created_at])
   end
@@ -13,12 +14,27 @@ class UserController < ApplicationController
       if user.errors[:email] === ["has already been taken"]
         render json: { message: '既に登録されています', data: user.errors[:email] }, status: 409
       else
-        render json: { message: '正しく入力してください', data: user.errors}, status: 400
+        render json: { message: '正確な情報を入力してください', data: user.errors}, status: 400
       end
     end
   end
 
   def update
+    updated_user = User.find_by(id: user_update_params[:id])
+    if !user_update_params[:password] # パスワードの更新をしない場合
+      updated_user.name, updated_user.email, updated_user.user_discription = user_update_params[:name], user_update_params[:email], user_update_params[:user_discription]
+      if updated_user.save(context: :no_update_password) # バリデーションをかけない
+        render status: 204
+      else
+        render_updated_errors(updated_user)
+      end
+    else
+      if updated_user.update(user_update_params)
+        render status: 204
+      else
+        render_updated_errors(updated_user)
+      end
+    end
   end
 
   def delete
@@ -27,5 +43,17 @@ class UserController < ApplicationController
   private 
   def user_params
     params.permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def user_update_params
+    params.permit(:id, :user, :name, :email, :password, :password_confirmation, :user_discription)
+  end
+
+  def render_updated_errors(updated_user)
+    if updated_user.errors[:email] === ["has already been taken"]
+      render json: { message: '既に登録さているメールアドレスです', data: user.errors[:email] }, status: 409
+    else
+      render json: { mesage: '正確な情報を入力してください', data: updated_user.errors }, status: 400
+    end
   end
 end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -53,7 +53,7 @@ class UserController < ApplicationController
     if updated_user.errors[:email] === ["has already been taken"]
       render json: { message: '既に登録さているメールアドレスです', data: user.errors[:email] }, status: 409
     else
-      render json: { mesage: '正確な情報を入力してください', data: updated_user.errors }, status: 400
+      render json: { message: '正確な情報を入力してください', data: updated_user.errors }, status: 400
     end
   end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -20,6 +20,9 @@ class User < ApplicationRecord
                       format: { with: VALID_PASSWORD_REGEX }
   validates :password_confirmation, presence: true
 
+  validates :user_discription,
+                      length: { maximum: 400}
+
   # リフレッシュトークンのJWT IDを記憶する
   def remember(jti)
     update_column(:refresh_jti, jti)

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   end
 
   def response_json(payload = {})
-    as_json(only: [:id, :name, :email]).merge(payload).with_indifferent_access
+    as_json(only: [:id, :name, :email, :user_discription]).merge(payload).with_indifferent_access
   end
   
   private

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -15,10 +15,10 @@ class User < ApplicationRecord
                       format: { with: VALID_EMAIL_REGEX }
 
   VALID_PASSWORD_REGEX = /\A[\w\-]+\z/
-  validates :password, confirmation: true, presence: true,
+  validates :password, confirmation: true, presence: true, on: :password,
                       length: { minimum: 8, maximum: 100 },
                       format: { with: VALID_PASSWORD_REGEX }
-  validates :password_confirmation, presence: true
+  validates :password_confirmation, presence: true, on: :password_confirmation
 
   validates :user_discription,
                       length: { maximum: 400}

--- a/api/db/migrate/20221120142225_adduser_discription_to_users.rb
+++ b/api/db/migrate/20221120142225_adduser_discription_to_users.rb
@@ -1,0 +1,5 @@
+class AdduserDiscriptionToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :user_discription, :string
+  end
+end

--- a/api/db/migrate/20221122101904_change_data_column_to_varchar.rb
+++ b/api/db/migrate/20221122101904_change_data_column_to_varchar.rb
@@ -1,0 +1,5 @@
+class ChangeDataColumnToVarchar < ActiveRecord::Migration[6.0]
+  def change
+    change_column :users, :user_discription, :text
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_19_145833) do
+ActiveRecord::Schema.define(version: 2022_11_20_142225) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "body"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2022_10_19_145833) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "refresh_jti"
+    t.string "user_discription"
   end
 
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_20_142225) do
+ActiveRecord::Schema.define(version: 2022_11_22_101904) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "body"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2022_11_20_142225) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "refresh_jti"
-    t.string "user_discription"
+    t.text "user_discription"
   end
 
 end

--- a/front/src/components/HeaderBar/HeaderUserinfo.vue
+++ b/front/src/components/HeaderBar/HeaderUserinfo.vue
@@ -14,7 +14,7 @@
       </div>
     </a>
     <div class="absolute top-11 -left-5 min-w-max p-5 shadow-lg text-sm bg-white" v-if="settingDrower">
-      <div class="mb-2 cursor-pointer">設定</div>
+      <router-link :to="{ path: `/setting/${currentUserInfo.id}` }"><div class="mb-2 cursor-pointer">設定</div></router-link>
       <div class="cursor-pointer" @click="Logout">ログアウト</div>
     </div>
   </div>

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -12,33 +12,46 @@
         <div class="shadow sm:overflow-hidden sm:rounded-md">
           <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
             <div class="grid grid-cols-6 gap-6">
-              <div class="col-span-6 sm:col-span-3 p-3 pb-2 border border-gray-300 border-solid rounded-md">
+              <div class="col-span-6 sm:col-span-3 p-2 border border-gray-300 border-solid rounded-md">
                 <label for="user-name" class="block text-sm font-medium text-gray-400">ユーザー名</label>
-                <input type="text" name="user-name" id="user-name" autocomplete="given-name"
+                <input type="text" v-model="currentUserInfo.name" name="user-name" id="user-name" autocomplete="given-name"
                   class="mt-1 block w-full rounded-md outline-none sm:text-base " />
               </div>
-              <div class="col-span-6 sm:col-span-4 p-3 pb-2 border border-gray-300 border-solid rounded-md">
+              <div class="col-span-6 sm:col-span-4 p-2 border border-gray-300 border-solid rounded-md">
                 <label for="email-address" class="block text-sm font-medium text-gray-400">メールアドレス</label>
-                <input type="text" name="email-address" id="email-address" autocomplete="email"
+                <input type="text" v-model="currentUserInfo.email" name="email-address" id="email-address" autocomplete="email"
                   class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
               </div>
             </div>
             <div>
-              <button class="rounded-md border border-gray-300 bg-white py-2 px-3 text-sm font-medium leading-4 text-gray-600 hover:bg-gray-100 focus:outline-none ">
+              <button v-if="!changePasswordArea" @click="changePasswordArea = true" class="rounded-md border border-gray-300 bg-white py-2 px-3 text-sm font-medium leading-4 text-gray-600 hover:bg-gray-100 focus:outline-none ">
                 パスワードを変更
-                <input id="file-upload" name="file-upload" type="file" class="sr-only" />
               </button>
+              <div v-if="changePasswordArea" class="col-span-6 sm:col-span-4 p-3 pb-2 border border-gray-300 border-solid rounded-md">
+                <label for="password" class="block text-sm font-medium text-gray-400">新規パスワード</label>
+                <input type="password" v-model="currentUserInfo.password" 
+                  name="password" id="password" autocomplete="password" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
+                <label for="password_confirmation" class="block text-sm font-medium text-gray-400">新規パスワード確認</label>
+                <input type="password" v-model="currentUserInfo.password_confirmation"
+                  name="password_confirmation" id="password_confirmation" autocomplete="password_confirmation" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
+                <div class="text-right">    
+                  <button @click="changePasswordArea = false"
+                  class="inline-flex justify-center rounded-md border border-transparent bg-gray-300 py-2 px-3 text-xs font- text-white shadow-sm  focus:ring-offset-2">
+                  キャンセル
+                </button>
+              </div>
+              </div>
             </div>
-            <div class="p-3 pb-2 border border-gray-300 border-solid rounded-md">
-              <label for="about" class="block text-sm font-medium text-gray-400">About</label>
+            <div class="p-2 border border-gray-300 border-solid rounded-md">
+              <label for="about" class="block text-sm font-medium text-gray-400">自己紹介</label>
               <div class="mt-1">
-                <textarea id="about" name="about" rows="3" class="mt-1 block w-full rounded-md outline-none  sm:text-base resize-none text-base" />
+                <textarea v-model="currentUserInfo.user_discription" id="about" name="about" rows="3" class="mt-1 block w-full rounded-md outline-none  sm:text-base resize-none text-base" />
               </div>
             </div>
 
             <div>
               <div class="mt-1 flex items-center">
-                <span class="inline-block h-12 w-12 overflow-hidden rounded-full bg-gray-100">
+                <span class="inline-block h-16 w-16 overflow-hidden rounded-full bg-gray-100">
                   <svg class="h-full w-full text-gray-300" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
                   </svg>
@@ -51,7 +64,10 @@
             </div>
           </div>
           <div class="bg-gray-50 px-5 py-3 text-right sm:px-6">
-            <button type="submit" class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">更新</button>
+            <button type="submit" @click="submitUpdateInfo"
+              class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+              更新
+            </button>
           </div>
         </div>
       </div>
@@ -65,27 +81,6 @@
   </div>
 </template>
 
-<!-- <template>
-  <div class="flex justify-center h-full py-14">
-    <div class="container lg: py-14">
-      <form class="w-full max-w-sm m-auto">
-        <UserFormEmail v-model:user-email="userEmail" />
-        <UserFormPassword v-model:user-password="userPassword" />
-        <div class="md:flex md:items-center">
-          <div class="md:w-1/3"></div>
-          <div class="md:w-2/3">
-            <button @click="Login"
-              class="shadow bg-blue-500 hover:bg-blue-400 duration-200 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
-              type="button">
-              更新
-            </button>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
-</template> -->
-
 <script>
 import UserFormEmail from '../UsreForm/UserFormEmail.vue'
 import UserFormPassword from '../UsreForm/UserFormPassword.vue'
@@ -93,8 +88,46 @@ export default {
   components: {
     UserFormEmail,
     UserFormPassword,
+  },
+  data() {
+    return {
+      currentUserInfo: {
+        id: '',
+        name: '',
+        email: '',
+        password: '',
+        password_confirmation: '',
+        user_discription: ''
+      },
+      changePasswordArea: false
+    }
+  },
+  methods: {
+    async submitUpdateInfo() {
+      const update_params = {
+        name: this.currentUserInfo.name,
+        email: this.currentUserInfo.email,
+        password: this.currentUserInfo.password,
+        password_confirmation: this.currentUserInfo.password_confirmation,
+        user_discription: this.currentUserInfo.user_discription
+      }
+    // パスワードの変更がなかった際はパラメータから削除
+      if (update_params.password === '' || update_params.password_confirmation === '') {
+        delete update_params.password
+        delete update_params.password_confirmation
+      }
+      console.log(update_params)
+      await this.axios.patch(`user/${this.currentUserInfo.id}`, update_params)
+      .then( response => console.log(response))
+      .catch( error => console.log(error))
+    },
+  },
+  created() {
+    const gettersCurrentUser = this.$store.getters.current_user
+    // あらかじめユーザー情報をフォームに出力
+    this.currentUserInfo.id = gettersCurrentUser.id; this.currentUserInfo.name = gettersCurrentUser.name; this.currentUserInfo.email = gettersCurrentUser.email
+    gettersCurrentUser.user_discription ? this.currentUserInfo.user_discription = gettersCurrentUser.user_discription : this.currentUserInfo.user_discription = ''
   }
-  
 }
 </script>
 

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -118,8 +118,16 @@ export default {
       }
       console.log(update_params)
       await this.axios.patch(`user/${this.currentUserInfo.id}`, update_params)
-      .then( response => console.log(response))
-      .catch( error => console.log(error))
+        .then(() => {
+          this.$router.push('/home')
+          const message = 'ユーザー情報を更新しました'; const color = 'bg-blue-500';
+          this.$store.dispatch('getToast', { message, color })
+      })
+        .catch(error => {
+          const message = error.response.data.message
+          console.log(error.response.data)
+          this.$store.dispatch('getToast', { message })
+      })
     },
   },
   created() {

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -1,0 +1,103 @@
+
+<template>
+  <div class="pt-6"> 
+    <div class="md:grid md:grid-cols-4 md:gap-6">
+      <div class="md:col-span-1">
+        <div class="px-4 sm:px-0">
+          <h3 class="text-lg font-medium leading-6 text-gray-900 pl-6">ユーザー情報</h3>
+          <p class="mt-1 text-sm text-gray-600"></p>
+        </div>
+      </div>
+      <div class="mt-5 md:col-span-3 md:mt-0">
+        <div class="shadow sm:overflow-hidden sm:rounded-md">
+          <div class="space-y-6 bg-white px-4 py-5 sm:p-6">
+            <div class="grid grid-cols-6 gap-6">
+              <div class="col-span-6 sm:col-span-3 p-3 pb-2 border border-gray-300 border-solid rounded-md">
+                <label for="user-name" class="block text-sm font-medium text-gray-400">ユーザー名</label>
+                <input type="text" name="user-name" id="user-name" autocomplete="given-name"
+                  class="mt-1 block w-full rounded-md outline-none sm:text-base " />
+              </div>
+              <div class="col-span-6 sm:col-span-4 p-3 pb-2 border border-gray-300 border-solid rounded-md">
+                <label for="email-address" class="block text-sm font-medium text-gray-400">メールアドレス</label>
+                <input type="text" name="email-address" id="email-address" autocomplete="email"
+                  class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
+              </div>
+            </div>
+            <div>
+              <button class="rounded-md border border-gray-300 bg-white py-2 px-3 text-sm font-medium leading-4 text-gray-600 hover:bg-gray-100 focus:outline-none ">
+                パスワードを変更
+                <input id="file-upload" name="file-upload" type="file" class="sr-only" />
+              </button>
+            </div>
+            <div class="p-3 pb-2 border border-gray-300 border-solid rounded-md">
+              <label for="about" class="block text-sm font-medium text-gray-400">About</label>
+              <div class="mt-1">
+                <textarea id="about" name="about" rows="3" class="mt-1 block w-full rounded-md outline-none  sm:text-base resize-none text-base" />
+              </div>
+            </div>
+
+            <div>
+              <div class="mt-1 flex items-center">
+                <span class="inline-block h-12 w-12 overflow-hidden rounded-full bg-gray-100">
+                  <svg class="h-full w-full text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
+                  </svg>
+                </span>
+                <label for="file-upload" class="ml-5 rounded-md border border-gray-300 bg-white py-2 px-3 text-sm font-medium leading-4 text-gray-700 shadow-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                  画像を変更
+                  <input id="file-upload" name="file-upload" type="file" class="sr-only" />
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="bg-gray-50 px-5 py-3 text-right sm:px-6">
+            <button type="submit" class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">更新</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="hidden sm:block" aria-hidden="true">
+      <div class="py-5">
+        <div class="border-t border-gray-200" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<!-- <template>
+  <div class="flex justify-center h-full py-14">
+    <div class="container lg: py-14">
+      <form class="w-full max-w-sm m-auto">
+        <UserFormEmail v-model:user-email="userEmail" />
+        <UserFormPassword v-model:user-password="userPassword" />
+        <div class="md:flex md:items-center">
+          <div class="md:w-1/3"></div>
+          <div class="md:w-2/3">
+            <button @click="Login"
+              class="shadow bg-blue-500 hover:bg-blue-400 duration-200 focus:shadow-outline focus:outline-none text-white font-bold py-2 px-4 rounded"
+              type="button">
+              更新
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template> -->
+
+<script>
+import UserFormEmail from '../UsreForm/UserFormEmail.vue'
+import UserFormPassword from '../UsreForm/UserFormPassword.vue'
+export default {
+  components: {
+    UserFormEmail,
+    UserFormPassword,
+  }
+  
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -14,12 +14,12 @@
             <div class="grid grid-cols-6 gap-6">
               <div class="col-span-6 sm:col-span-3 p-2 border border-gray-300 border-solid rounded-md">
                 <label for="user-name" class="block text-sm font-medium text-gray-400">ユーザー名</label>
-                <input type="text" v-model="currentUserInfo.name" name="user-name" id="user-name" autocomplete="given-name"
+                <input type="text" v-model="currentUserInfo.name" name="user-name" id="user-name" autocomplete="off"
                   class="mt-1 block w-full rounded-md outline-none sm:text-base " />
               </div>
               <div class="col-span-6 sm:col-span-4 p-2 border border-gray-300 border-solid rounded-md">
                 <label for="email-address" class="block text-sm font-medium text-gray-400">メールアドレス</label>
-                <input type="text" v-model="currentUserInfo.email" name="email-address" id="email-address" autocomplete="email"
+                <input type="text" v-model="currentUserInfo.email" name="email-address" id="email-address" autocomplete="off"
                   class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
               </div>
             </div>
@@ -30,10 +30,10 @@
               <div v-if="changePasswordArea" class="col-span-6 sm:col-span-4 p-3 pb-2 border border-gray-300 border-solid rounded-md">
                 <label for="password" class="block text-sm font-medium text-gray-400">新規パスワード</label>
                 <input type="password" v-model="currentUserInfo.password" 
-                  name="password" id="password" autocomplete="password" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
+                  name="password" id="password" autocomplete="off" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
                 <label for="password_confirmation" class="block text-sm font-medium text-gray-400">新規パスワード確認</label>
                 <input type="password" v-model="currentUserInfo.password_confirmation"
-                  name="password_confirmation" id="password_confirmation" autocomplete="password_confirmation" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
+                  name="password_confirmation" id="password_confirmation" autocomplete="off" class="mt-1 block w-full rounded-md outline-none sm:text-base border-none" />
                 <div class="text-right">    
                   <button @click="changePasswordArea = false"
                   class="inline-flex justify-center rounded-md border border-transparent bg-gray-300 py-2 px-3 text-xs font- text-white shadow-sm  focus:ring-offset-2">
@@ -64,8 +64,9 @@
             </div>
           </div>
           <div class="bg-gray-50 px-5 py-3 text-right sm:px-6">
-            <button type="submit" @click="submitUpdateInfo"
-              class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+            <button type="submit" @click="submitUpdateInfo" :disabled="submitButtonDisabled" 
+              :class="{ 'bg-indigo-300': submitButtonDisabled === true, 'bg-indigo-600': submitButtonDisabled === false, 'hover:bg-indigo-700': submitButtonDisabled === false}"
+              class="inline-flex justify-center rounded-md border border-transparent  py-2 px-4 text-sm font-medium text-white shadow-sm  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
               更新
             </button>
           </div>
@@ -99,7 +100,8 @@ export default {
         password_confirmation: '',
         user_discription: ''
       },
-      changePasswordArea: false
+      changePasswordArea: false,
+      submitButtonDisabled: false
     }
   },
   methods: {
@@ -116,7 +118,6 @@ export default {
         delete update_params.password
         delete update_params.password_confirmation
       }
-      console.log(update_params)
       await this.axios.patch(`user/${this.currentUserInfo.id}`, update_params)
         .then(() => {
           this.$router.push('/home')
@@ -125,7 +126,6 @@ export default {
       })
         .catch(error => {
           const message = error.response.data.message
-          console.log(error.response.data)
           this.$store.dispatch('getToast', { message })
       })
     },
@@ -135,7 +135,47 @@ export default {
     // あらかじめユーザー情報をフォームに出力
     this.currentUserInfo.id = gettersCurrentUser.id; this.currentUserInfo.name = gettersCurrentUser.name; this.currentUserInfo.email = gettersCurrentUser.email
     gettersCurrentUser.user_discription ? this.currentUserInfo.user_discription = gettersCurrentUser.user_discription : this.currentUserInfo.user_discription = ''
+  },
+  updated() {
+    // フォームに入力された値のバリデーション
+    if (this.currentUserInfo.name === '' || this.currentUserInfo.name.length > 30) {
+      this.submitButtonDisabled = true
+      return
+    }
+    if (this.currentUserInfo.email === '' || this.currentUserInfo.email.length > 100) {
+      this.submitButtonDisabled = true
+      return
+    }
+    const emailReg = new RegExp(/^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]{1,}\.[A-Za-z0-9]{1,}$/)
+    if (!emailReg.test(this.currentUserInfo.email)) {
+      this.submitButtonDisabled = true
+      return
+    }
+    if (this.changePasswordArea) {
+      if (this.currentUserInfo.password === '' || this.currentUserInfo.password.length < 8) {
+        this.submitButtonDisabled = true
+        return
+    }
+    if (this.currentUserInfo.password.length > 100) {
+      this.submitButtonDisabled = true
+      return
+    }
+    const passwordReg = /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,100}$/i
+    if (!passwordReg.test(this.currentUserInfo.password)) {
+      this.submitButtonDisabled = true
+      return
+    }
+    if (this.currentUserInfo.password !== this.currentUserInfo.password_confirmation) {
+      this.submitButtonDisabled = true
+      return
+    }
   }
+  if (this.currentUserInfo.user_discription.length > 400) {
+    this.submitButtonDisabled = true
+    return
+  }
+    this.submitButtonDisabled = false
+  },
 }
 </script>
 

--- a/front/src/components/pages/SignUpPage.vue
+++ b/front/src/components/pages/SignUpPage.vue
@@ -86,11 +86,11 @@ export default  {
 
   updated() {
     // フォームに入力された値のバリデーション
-    if (this.userName === '' && this.userName.length > 30) {
+    if (this.userName === '' || this.userName.length > 30) {
       this.disabled = true
       return
     }
-    if (this.userEmail === '' && this.userEmail.length > 100) {
+    if (this.userEmail === '' || this.userEmail.length > 100) {
       this.disabled = true
       return
     }
@@ -99,7 +99,7 @@ export default  {
       this.disabled = true
       return
     }
-    if (this.userPassword === '' && this.userPassword.length < 8) {
+    if (this.userPassword === '' || this.userPassword.length < 8) {
       this.disabled = true
       return
     }

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import HomePage from "../components/pages/HomePage.vue";
 import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
+import SettingUserInfo from "../components/pages/SettingUserInfo.vue";
 import NotFoundError from '../components/pages/error/NotFound.vue';
 import InternalServerError from '../components/pages/error/InternalServerError.vue';
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
@@ -24,6 +25,11 @@ const routes = [
     path: "/login",
     name: "Login",
     component: LoginPage,
+  },
+  {
+    path: "/setting/:id/",
+    name: "UserSetting",
+    component: SettingUserInfo
   },
   {
     path: '/error',


### PR DESCRIPTION
## 概要
ユーザー情報の設定を更新する画面を作成した。
またユーザー名・メールアドレス・パスワード・自己紹介を更新できるAPIメソッドを作成し、利用できるようにした。
自己紹介カラムについては新規に追加し、新規登録時ではなく、設定から追加が可能な仕様とした。
close #66
close #50 
## やったこと
* ユーザー情報の設定ボタンを押下した際ユーザー情報を更新できる画面を作成
  *  ユーザー名・メールアドレス・パスワード・自己紹介が更新できる(後にアイコン画像も更新可能にしている)
  * URLに関しては`/setting/{user_id}`の形とした
* ユーザー情報を更新する際にパスワードを更新する場合としない場合を設けた
  *  パスワードに関してはフロント側で情報がないため更新が必要なくてもデフォルトでフォームに埋め込むことができないためこのような対応をとった
*  更新が完了するとトースターが出現し、`/home`へリダイレクトされる
* user_discriptionカラムを追加し、自己紹介を登録できるようにした。
  *  自己紹介に関しては400文字が制限とし、必須項目ではない
  * リフレッシュトークンやアクセストークンが発行されたときに返されるレスポンスにデータを持たせVuexのcurrent_userにユーザー情報の一部として保存している。
* ユーザー情報の更新に失敗した場合はエラー用のトースターを出現させる
  *  バリデーションに関しては新規登録時のフォームとほぼ同じものを採用している。
  *  
## 確認項目
- [x] 正常にDBの更新が行え、Vuexに値が保存されているか
- [x] 更新成功した際、適切なトースターが出力され、/homeに画面遷移しているか
- [x] 更新失敗時にエラートースターが出力されているか
- [x] バリデーションが作用し、ボタンの活性・非活性が期待通り動作しているか

## その他
アイコン画像の更新も行えるようにする　#62 
