### PR TITLE
ユーザーアイコンを設定できるように機能追加

### DIFF
--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -20,10 +20,10 @@ class PostsController < ApplicationController
   def index
     post_all = Post.all
     add_username_post_all = post_all.map do |post| 
-      posted_user_name = User.find_by(id: post[:user_id]).name
+      posted_user = User.find_by(id: post[:user_id])
       { 
         "id" => post.id, "body" => post.body, "created_at" => post.created_at, "updated_at" => post.updated_at, 
-        "user_id" => post.user_id, "user_name" => posted_user_name
+        "user_id" => post.user_id, "user_name" => posted_user.name, "image_icon" => posted_user.image_url
       }
     end
     render json: add_username_post_all

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -25,9 +25,9 @@ class UserController < ApplicationController
     updated_user = User.find(user_update_params[:id])
     if !user_update_params[:password] # パスワードの更新をしない場合
       updated_user.parse_base64(updated_user, user_update_params[:image_icon]) if user_update_params[:image_icon]
-      updated_user.name, updated_user.email, updated_user.user_discription = user_update_params[:name], user_update_params[:email], user_update_params[:user_discription], 
+      updated_user.name, updated_user.email, updated_user.user_discription = user_update_params[:name], user_update_params[:email], user_update_params[:user_discription]
       if updated_user.save(context: :no_update_password) # パスワードのカラムにバリデーションをかけない
-        render status: 204
+        render_updated_success_response(updated_user)
       else
         render_updated_errors(updated_user)
       end
@@ -35,7 +35,7 @@ class UserController < ApplicationController
       updated_user.parse_base64(updated_user, user_update_params[:image_icon]) if user_update_params[:image_icon]
       user_update_params_remove_image = {name:user_update_params[:name], email:user_update_params[:email], password:user_update_params[:password], user_discription:user_update_params[:user_discription]}
       if updated_user.update(user_update_params_remove_image)
-        render status: 204
+        render_updated_success_response(updated_user)
       else
         render_updated_errors(updated_user)
       end
@@ -52,6 +52,11 @@ class UserController < ApplicationController
 
   def user_update_params
     params.permit(:id, :name, :email, :password, :password_confirmation, :user_discription, :image_icon)
+  end
+
+  def render_updated_success_response(updated_user)
+    response_user_data = User.select("id", "name", "email", "user_discription").find(user_update_params[:id])
+    render json: response_user_data, methods: :image_url
   end
 
   def render_updated_errors(updated_user)

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   end
 
   def response_json(payload = {})
-    as_json(only: [:id, :name, :email, :user_discription]).merge(payload).with_indifferent_access
+    as_json(only: [:id, :name, :email, :user_discription], methods: :image_url).merge(payload).with_indifferent_access
   end
 
   # 紐づいている画像のURLを取得する
@@ -77,11 +77,6 @@ class User < ApplicationRecord
     end
 
     def attach_image(updated_user,filename)
-      p "========="
-      p image_icon
-      p "model========="
-      p updated_user.image_icon
-      p "model========="
       updated_user.image_icon.attach(io: File.open("#{Rails.root}/tmp/#{filename}"), filename: filename)
       FileUtils.rm("#{Rails.root}/tmp/#{filename}")
     end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,10 +1,13 @@
 class User < ApplicationRecord
   include TokenGenerateService   # Token生成モジュール
+  include Rails.application.routes.url_helpers 
  # アソシエーション
+  has_secure_password
   has_many :posts
+  has_one_attached :image_icon # Active Recordによる疑似カラム生成
+  attr_accessor :image
 
   before_create :set_uuid
-  has_secure_password
 
   validates :name, presence: true,      
                       length: { maximum: 30 }
@@ -36,6 +39,24 @@ class User < ApplicationRecord
   def response_json(payload = {})
     as_json(only: [:id, :name, :email, :user_discription]).merge(payload).with_indifferent_access
   end
+
+  # 紐づいている画像のURLを取得する
+  def image_url
+    image_icon.attached? ? url_for(image_icon) : nil
+  end
+
+  def parse_base64(updated_user,image)
+    if image.present? || rex_image(image) == ''
+      content_type = create_extension(image)
+      contents = image.sub %r/data:((image|application)\/.{3,}),/, ''
+      decoded_data = Base64.decode64(contents)
+      filename = Time.zone.now.to_s + '.' + content_type
+      File.open("#{Rails.root}/tmp/#{filename}", 'wb') do |f|
+        f.write(decoded_data)
+      end
+    end
+    attach_image(updated_user,filename)
+  end
   
   private
     def set_uuid
@@ -44,5 +65,24 @@ class User < ApplicationRecord
         # ランダムな20文字をidに設定
         self.id = SecureRandom.alphanumeric(20)
       end
+    end
+
+    def create_extension(image)
+      content_type = rex_image(image)
+      content_type[%r/\b(?!.*\/).*/]
+    end
+
+    def rex_image(image)
+      image[%r/(image\/[a-z]{3,4})|(application\/[a-z]{3,4})/]
+    end
+
+    def attach_image(updated_user,filename)
+      p "========="
+      p image_icon
+      p "model========="
+      p updated_user.image_icon
+      p "model========="
+      updated_user.image_icon.attach(io: File.open("#{Rails.root}/tmp/#{filename}"), filename: filename)
+      FileUtils.rm("#{Rails.root}/tmp/#{filename}")
     end
 end

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # ActiveStorage 
+  Rails.application.routes.default_url_options[:host] = 'localhost'
+  Rails.application.routes.default_url_options[:port] = 8000
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/api/db/migrate/20221123031646_create_active_storage_tables.active_storage.rb
+++ b/api/db/migrate/20221123031646_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/api/db/migrate/20221126055814_change_data_record_id_to_active_storage_attachments.rb
+++ b/api/db/migrate/20221126055814_change_data_record_id_to_active_storage_attachments.rb
@@ -1,0 +1,5 @@
+class ChangeDataRecordIdToActiveStorageAttachments < ActiveRecord::Migration[6.0]
+  def change
+      change_column :active_storage_attachments, :record_id, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_22_101904) do
+ActiveRecord::Schema.define(version: 2022_11_23_031646) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "body"
@@ -30,4 +51,5 @@ ActiveRecord::Schema.define(version: 2022_11_22_101904) do
     t.text "user_discription"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_23_031646) do
+ActiveRecord::Schema.define(version: 2022_11_26_055814) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
+    t.string "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"

--- a/front/src/components/HeaderBar/HeaderUserinfo.vue
+++ b/front/src/components/HeaderBar/HeaderUserinfo.vue
@@ -2,9 +2,15 @@
   <div ref="wrapper" class="relative settingDrawer_wrapper">
     <a href="#" class="flex-shrink-0 group block" @click="showDrower">
       <div class="flex items-center group-hover:opacity-60 duration-200">
-        <div>
-          <img class="inline-block  md:h-10 md:w-10 h-9 w-9  rounded-full"
-            src="https://pbs.twimg.com/profile_images/1121328878142853120/e-rpjoJi_bigger.png" alt="" />
+        <div class="flex align-middle">
+          <span v-if="currentUserInfo.image_url" class=" h-10 w-10 inline-block md:w-12 md:h-12 overflow-hidden rounded-full">
+            <img :src="currentUserInfo.image_url" alt="" />
+          </span>
+          <span v-if="!currentUserInfo.image_url" class=" h-10 w-10 inline-block md:w-12 md:h-12 overflow-hidden rounded-full bg-gray-100">
+            <svg class="h-full w-full text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+          </span>
         </div>
         <div class="ml-3 hidden md:block">
           <p class="text-sm leading-6 font-medium">

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -4,7 +4,10 @@
     <div class="relative flex flex-shrink-0 p-4 pb-0">
       <a href="#" class="flex-shrink-0 group block">
         <div class="flex items-center">
-          <PostUserinfo :postedUserName="post.user_name" />
+          <PostUserinfo 
+          :postedUserName="post.user_name" 
+          :postedUserIcon="post.image_icon"
+          />
         </div>
       </a>
       <div class="m-auto text-sm leading-5 ml-2 font-medium text-gray-400">

--- a/front/src/components/PostList/PostUserinfo.vue
+++ b/front/src/components/PostList/PostUserinfo.vue
@@ -1,7 +1,14 @@
 <template>
   <a href="#" class="flex items-center group-hover:opacity-60 duration-200">
     <div>
-      <img class="inline-block h-10 w-10 rounded-full" src="https://pbs.twimg.com/profile_images/1121328878142853120/e-rpjoJi_bigger.png" alt="" />
+      <span v-if="postedUserIcon" class="h-10 w-10 inline-block overflow-hidden rounded-full">
+        <img :src="postedUserIcon" alt="" />
+      </span>
+      <span v-if="!postedUserIcon" class="h-10 w-10 inline-block overflow-hidden rounded-full bg-gray-100">
+        <svg class="h-full w-full text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      </span>
     </div>
     <div class="ml-3">
       <span class="text-sm leading-6 font-medium ">
@@ -15,6 +22,9 @@
 export default {
   props: {
     postedUserName: {
+      type:String
+    },
+    postedUserIcon: {
       type:String
     }
   }

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -58,8 +58,12 @@
                 </span>
                 <label for="file-upload" class="ml-5 rounded-md border border-gray-300 bg-white py-2 px-3 text-sm font-medium leading-4 text-gray-700 shadow-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                   画像を変更
-                  <input id="file-upload" name="file-upload" type="file" class="sr-only" />
+                  <input @change="setImageIcon" id="file-upload" name="file-upload" type="file" class="sr-only" />
                 </label>
+                <div v-if="previewImageIcon" class="flex items-center">
+                  <span class="ml-2">{{ previewImageIcon.name }}</span>
+                  <img :src="currentUserInfo.ImageIconBase64" alt="" class=" h-16 w-16 ml-4">
+                </div>
               </div>
             </div>
           </div>
@@ -98,20 +102,37 @@ export default {
         email: '',
         password: '',
         password_confirmation: '',
-        user_discription: ''
+        user_discription: '',
+        ImageIconBase64: null
       },
       changePasswordArea: false,
-      submitButtonDisabled: false
+      submitButtonDisabled: false,
+      previewImageIcon: null
     }
   },
   methods: {
+    setImageIcon(e) {
+      e.preventDefault()
+      this.previewImageIcon = e.target.files[0]
+      const reader = new FileReader()
+      if (this.previewImageIcon) {
+        reader.readAsDataURL(this.previewImageIcon)
+      } else {
+        this.currentUserInfo.ImageIconBase64 = ''
+      }
+      // 変換が終わったら実行される
+      reader.onload = () => {
+        this.currentUserInfo.ImageIconBase64 = reader.result
+      }
+    },
     async submitUpdateInfo() {
       const update_params = {
         name: this.currentUserInfo.name,
         email: this.currentUserInfo.email,
         password: this.currentUserInfo.password,
         password_confirmation: this.currentUserInfo.password_confirmation,
-        user_discription: this.currentUserInfo.user_discription
+        user_discription: this.currentUserInfo.user_discription,
+        image_icon: this.currentUserInfo.ImageIconBase64
       }
     // パスワードの変更がなかった際はパラメータから削除
       if (update_params.password === '' || update_params.password_confirmation === '') {

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -51,7 +51,10 @@
 
             <div>
               <div class="mt-1 flex items-center">
-                <span class="inline-block h-16 w-16 overflow-hidden rounded-full bg-gray-100">
+                <span v-if="this.$store.getters.current_user.image_url" class="inline-block h-16 w-16 overflow-hidden rounded-full">
+                  <img :src=this.$store.getters.current_user.image_url alt="" >
+                </span>
+                <span v-if="!this.$store.getters.current_user.image_url" class="inline-block h-16 w-16 overflow-hidden rounded-full bg-gray-100">
                   <svg class="h-full w-full text-gray-300" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
                   </svg>
@@ -140,7 +143,8 @@ export default {
         delete update_params.password_confirmation
       }
       await this.axios.patch(`user/${this.currentUserInfo.id}`, update_params)
-        .then(() => {
+        .then((response) => {
+          this.$store.dispatch('getCurrentUser', response.data)
           this.$router.push('/home')
           const message = 'ユーザー情報を更新しました'; const color = 'bg-blue-500';
           this.$store.dispatch('getToast', { message, color })

--- a/front/src/components/pages/SettingUserInfo.vue
+++ b/front/src/components/pages/SettingUserInfo.vue
@@ -144,16 +144,19 @@ export default {
       }
       await this.axios.patch(`user/${this.currentUserInfo.id}`, update_params)
         .then((response) => {
-          this.$store.dispatch('getCurrentUser', response.data)
-          this.$router.push('/home')
-          const message = 'ユーザー情報を更新しました'; const color = 'bg-blue-500';
-          this.$store.dispatch('getToast', { message, color })
+          this.user_update_success(response.data) 
       })
         .catch(error => {
           const message = error.response.data.message
           this.$store.dispatch('getToast', { message })
       })
     },
+    async user_update_success(response) {
+      await this.$store.dispatch('getCurrentUser', response)
+      await this.$router.push('/home')
+      const message = 'ユーザー情報を更新しました'; const color = 'bg-blue-500';
+      this.$store.dispatch('getToast', { message, color })
+    }
   },
   created() {
     const gettersCurrentUser = this.$store.getters.current_user


### PR DESCRIPTION
## 概要
ユーザー情報を更新する画面からユーザーアイコンを設定できるように機能を追加した。
また投稿一覧やヘッダーでユーザーごとのアイコンが表示されるように修正した。
close #62 
close #65 
close #66 

## やったこと
* 更新ボタンを押下した際に更新内容が瞬時に反映されるように修正
  *  フロント側でVuexのGettersに更新した内容を書き換え表示のみを変更
  * 非同期でDB側のデータは更新
* ユーザー情報を更新する画面からユーザーアイコンを設定できるように機能追加
  *  Rails API側ではActiveStorageを利用し、Userにimage_iconとして画像データを関連づけし、フロント側から呼び出せるようにした。
  * フロントからAPIへ画像をアップロードする際、JSONでやりとりするべく、画像をBase64の形式にエンコードして送信し、API側でデコードするようにした。
  * UserIDをStringとして保存しているためUserに紐づくrecord_idもStringとした
* ヘッダーのユーザーアイコンを表示する箇所にログインユーザーのアイコンを表示
* 投稿一覧の投稿にも投稿したユーザーのアイコンを表示
* アイコン画像を設定していない場合はデフォルトのアイコンとしてSVNのアイコンを表示する
![スクリーンショット 2022-11-27 18 44 51](https://user-images.githubusercontent.com/76101803/204128800-46f0ebbd-2947-4681-b723-71dd10c49e2f.png)

## 確認項目
- [x] 画像をアップロードできるか
- [x] アイコン画像が適切に表示されているか
- [x] 更新に失敗した際、成功した際に正しい挙動となっているか

## その他
今後は画像をリサイズして、画像ごとに適切な表示ができるようにする