### PR TITLE
フォロー・フォロワー機能のAPIを実装

### DIFF
--- a/api/app/controllers/relationships_controller.rb
+++ b/api/app/controllers/relationships_controller.rb
@@ -1,0 +1,14 @@
+class RelationshipsController < ApplicationController
+  include UserSessionizeService
+
+  def create
+    session_user.follow(params[:user_id])
+    render status: 201
+  end
+
+  def destroy
+    session_user.unfollow(params[:user_id])
+    render status: 204
+  end
+
+end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -47,9 +47,9 @@ class UserController < ApplicationController
 
   def relationship_list
     user = User.find(params[:id])
-    following_users = user.following_user.pluck(:id, :name)
-    follower_users = user.follower_user.pluck(:id, :name)
-    render json: { following: following_users, follower: follower_users}
+    following_user = relationship_list_select_column(user.following_user)
+    followerd_user = relationship_list_select_column(user.follower_user)
+    render json: {following: following_user, follower: followerd_user}
   end
 
   private 
@@ -71,6 +71,12 @@ class UserController < ApplicationController
       render json: { message: '既に登録さているメールアドレスです', data: user.errors[:email] }, status: 409
     else
       render json: { message: '正確な情報を入力してください', data: updated_user.errors }, status: 400
+    end
+  end
+
+  def relationship_list_select_column(relation_user)
+    relation_user.map do |user|
+      {id: user.id, name: user.name, discription:user.user_discription, icon: user.image_url}
     end
   end
 end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -45,6 +45,13 @@ class UserController < ApplicationController
   def delete
   end
 
+  def relationship_list
+    user = User.find(params[:id])
+    following_users = user.following_user.pluck(:id, :name)
+    follower_users = user.follower_user.pluck(:id, :name)
+    render json: { following: following_users, follower: follower_users}
+  end
+
   private 
   def user_params
     params.permit(:name, :email, :password, :password_confirmation)

--- a/api/app/models/relationship.rb
+++ b/api/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ApplicationRecord
 
   # ユーザーをフォローする
   def follow(user_id)
-    follower.create(followed_id: user_id)
+    follower.find_or_create_by(followed_id: user_id)
   end
 
   # ユーザーのフォローを外す

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -2,8 +2,12 @@ class User < ApplicationRecord
   include TokenGenerateService   # Token生成モジュール
   include Rails.application.routes.url_helpers 
  # アソシエーション
-  has_secure_password
   has_many :posts
+  has_many :follower, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :followed, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :following_user, through: :follower, source: :followed # 自分がフォローしている人
+  has_many :follower_user, through: :followed, source: :follower # 自分をフォローしている人
+  has_secure_password
   has_one_attached :image_icon # Active Recordによる疑似カラム生成
   attr_accessor :image
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
  # アソシエーション
   has_many :posts
   has_many :follower, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
-  has_many :followed, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :followed, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :following_user, through: :follower, source: :followed # 自分がフォローしている人
   has_many :follower_user, through: :followed, source: :follower # 自分をフォローしている人
   has_secure_password

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -61,6 +61,21 @@ class User < ApplicationRecord
     end
     attach_image(updated_user,filename)
   end
+
+  # ユーザーをフォローする
+  def follow(user_id)
+    follower.create(followed_id: user_id)
+  end
+
+  # ユーザーのフォローを外す
+  def unfollow(user_id)
+    follower.find_by(followed_id: user_id).destroy
+  end
+
+  # フォローしていればtrueを返す
+  def following?(user)
+    following_user.include?(user)
+  end
   
   private
     def set_uuid

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'posts/create'
   resources :user, only:[:create, :index, :show, :edit, :update] do 
     member do
-      get :follows, :followers
+      get :relationship_list
     end
     resource :relationships, only: [:create, :destroy]
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
   get 'posts/index'
   get 'posts/show'
   get 'posts/create'
-  resources :user
+  resources :user, only:[:create, :index, :show, :edit, :update] do 
+    member do
+      get :follows, :followers
+    end
+    resource :relationships, only: [:create, :destroy]
+  end
 
   resources :posts  
 

--- a/api/db/migrate/20221211021550_create_relationships.rb
+++ b/api/db/migrate/20221211021550_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.references :follower, null: false, foreign_key: { to_table: :users }, type: :string 
+      t.references :followed, null: false, foreign_key: { to_table: :users }, type: :string 
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_26_055814) do
+ActiveRecord::Schema.define(version: 2022_12_11_021550) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,15 @@ ActiveRecord::Schema.define(version: 2022_11_26_055814) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "follower_id", null: false
+    t.string "followed_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+  end
+
   create_table "users", id: :string, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -52,4 +61,6 @@ ActiveRecord::Schema.define(version: 2022_11_26_055814) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "relationships", "users", column: "followed_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
 end


### PR DESCRIPTION
## 概要
ユーザー同士がフォローをしてフォロワー関係になれるAPIを作成
基本的には現在ログインしているユーザーが別のユーザーをフォローできる
フォローを解除することも可能
また特定のユーザーのフォローしている人とフォロワーを全て返すメソッドを作成
close #71

## やったこと
- フォローフォロワーを実現するためにrelationshipsテーブルを作成した。
  -  user_idとfollowing_id, user_idとfollowerd_idを紐づけることにより、フォローしている人とフォローされている人の関係をあらわしている。
- フォローするメソッドとフォローを解除するメソッド、フォローしているか確認するメソッドを作成した。
  -  フォローしている人とフォロワーに関しては名前とUserIDと自己紹介、アイコンの情報を返すようにしている

## 確認項目
APIのため確認にはPostmanを使用
- [x] ログインしているユーザーが特定のユーザーをフォローできたか
- [x] フォローしたユーザーをさくじょできるか
- [x] フォローしている人とフォロワーを全員表示できるか
- [x] ユーザー情報を返す際期待する情報だけが返ってきているか
- [x] ユーザーを重複してフォローできないようになっているか

## その他
