### PR TITLE
ユーザーごとのマイページを作成

### DIFF
--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -8,6 +8,11 @@ class UserController < ApplicationController
     render json: users, methods: [:image_url]
   end
 
+  def show
+    target_user = User.select("id","name","email","user_discription").find(params[:id])
+    render json: target_user, methods: [:image_url]
+  end
+
   def create
     user = User.new(user_params)
     if user.save

--- a/front/src/components/HeaderBar/HeaderUserinfo.vue
+++ b/front/src/components/HeaderBar/HeaderUserinfo.vue
@@ -20,6 +20,7 @@
       </div>
     </a>
     <div class="absolute top-11 -left-5 min-w-max p-5 shadow-lg text-sm bg-white" v-if="settingDrower">
+      <router-link :to="{ path: `/${currentUserInfo.id}` }"><div class="mb-2 cursor-pointer">マイページ</div></router-link>
       <router-link :to="{ path: `/setting/${currentUserInfo.id}` }"><div class="mb-2 cursor-pointer">設定</div></router-link>
       <div class="cursor-pointer" @click="Logout">ログアウト</div>
     </div>

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -5,6 +5,7 @@
       <a href="#" class="flex-shrink-0 group block">
         <div class="flex items-center">
           <PostUserinfo 
+          :postedUserId="post.user_id" 
           :postedUserName="post.user_name" 
           :postedUserIcon="post.image_icon"
           />

--- a/front/src/components/PostList/PostUserinfo.vue
+++ b/front/src/components/PostList/PostUserinfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <a href="#" class="flex items-center group-hover:opacity-60 duration-200">
+  <router-link :to="{ path: `/${postedUserId}`}" class="flex items-center group-hover:opacity-60 duration-200">
     <div>
       <span v-if="postedUserIcon" class="h-10 w-10 inline-block overflow-hidden rounded-full">
         <img :src="postedUserIcon" alt="" />
@@ -15,12 +15,15 @@
         {{ postedUserName }}
       </span>
     </div>
-  </a>
+  </router-link>
 </template>
 
 <script>
 export default {
   props: {
+    postedUserId: {
+      type:String
+    },
     postedUserName: {
       type:String
     },

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <div class="pt-12 pb-4 px-28">
+      <div class="flex justify-start border-b border-solid border-gray-300 px-6 pb-4">
+        <div class="px-14 py-6">
+          <svg class="w-28 h-28 overflow-hidden rounded-full bg-gray-100 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
+          </svg>
+          <!-- <figure class="inline-block w-28 h-28 overflow-hidden rounded-full">
+            <img :src=$store.getters.current_user.image_url alt="">
+          </figure> -->
+        </div>
+        <div class="px-4 break-words">
+          <div class="w-full my-4 flex items-center">
+            <span class="font-semibold">あいうえおかきくけこ</span>
+            <div class="flex cursor-pointer">
+              <span class="ml-6 px-2 py-1 text-xs font-semibold rounded-md border border-solid border-gray-400">プロフィールを編集</span>
+              <svg class="w-6 h-6 text-gray-600 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
+                </path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+              </svg>
+            </div>
+            <!-- <span class="ml-6 px-6 py-2 cursor-pointer font-semibold rounded-full text-xs text-white bg-blue-400">フォロー</span> -->
+          </div>
+          <div class="flex mb-4">
+            <span class="mr-6 text-sm">フォロワー<span class="font-bold">10</span>人</span><span class="text-sm">フォロー中<span class="font-bold">10</span>人</span>
+          </div>
+          <span class="w-full">自己紹介です自己紹介です自己紹介です自己紹介です自己紹介です自己紹介です</span>
+        </div>
+      </div>
+    </div>
+    <div class="flex justify-center h-full pb-20 pt-4">
+      <div class="container">
+        <div class="flex justify-center">
+          <div class="w-3/5 border border-gray-600 h-auto  border-t-0">
+            <Post />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Post from '../PostList/Post.vue'
+import post_list_fetch from '../../../plugins/post-list-fetch.js'
+export default {
+  components: {
+    Post
+  },
+  async created(){
+    await post_list_fetch()
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -7,7 +7,7 @@
             <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
           </svg>
           <figure v-if="userProfile.image_url" class="inline-block w-28 h-28 overflow-hidden rounded-full">
-            <img :src=userProfile.image_url alt="">
+            <img :src=userProfile.image_url>
           </figure>
         </div>
         <div class="px-4 break-words">
@@ -64,9 +64,7 @@ export default {
       this.userProfile = this.$store.getters.current_user
     }
     else {
-      this.axios.get(`/user/${user_id}`)
-        .then(res => this.userProfile = res.data)
-        .catch(error => this.$router.push) 
+      this.userProfile = this.$store.getters.userPage 
     }
     await post_list_fetch()
   }

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -3,31 +3,31 @@
     <div class="pt-12 pb-4 px-28">
       <div class="flex justify-start border-b border-solid border-gray-300 px-6 pb-4">
         <div class="px-14 py-6">
-          <svg class="w-28 h-28 overflow-hidden rounded-full bg-gray-100 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+          <svg v-if="!userProfile.image_url" class="w-28 h-28 overflow-hidden rounded-full bg-gray-100 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
             <path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" />
           </svg>
-          <!-- <figure class="inline-block w-28 h-28 overflow-hidden rounded-full">
-            <img :src=$store.getters.current_user.image_url alt="">
-          </figure> -->
+          <figure v-if="userProfile.image_url" class="inline-block w-28 h-28 overflow-hidden rounded-full">
+            <img :src=userProfile.image_url alt="">
+          </figure>
         </div>
         <div class="px-4 break-words">
           <div class="w-full my-4 flex items-center">
-            <span class="font-semibold">あいうえおかきくけこ</span>
-            <div class="flex cursor-pointer">
-              <span class="ml-6 px-2 py-1 text-xs font-semibold rounded-md border border-solid border-gray-400">プロフィールを編集</span>
-              <svg class="w-6 h-6 text-gray-600 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            <span class="font-semibold">{{ userProfile.name }}</span>
+              <router-link :to="{ path: `setting/${userProfile.id}`}" v-if="currentUserFlag" class="flex cursor-pointer">
+                <span class="ml-6 px-2 py-1 text-xs font-semibold rounded-md border border-solid border-gray-400">プロフィールを編集</span>
+                <svg class="w-6 h-6 text-gray-600 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
                 </path>
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
               </svg>
-            </div>
-            <!-- <span class="ml-6 px-6 py-2 cursor-pointer font-semibold rounded-full text-xs text-white bg-blue-400">フォロー</span> -->
+            </router-link>
+            <span v-if="!currentUserFlag" class="ml-6 px-6 py-2 cursor-pointer font-semibold rounded-full text-xs text-white bg-blue-400">フォロー</span>
           </div>
           <div class="flex mb-4">
             <span class="mr-6 text-sm">フォロワー<span class="font-bold">10</span>人</span><span class="text-sm">フォロー中<span class="font-bold">10</span>人</span>
           </div>
-          <span class="w-full">自己紹介です自己紹介です自己紹介です自己紹介です自己紹介です自己紹介です</span>
+          <span class="w-full">{{ userProfile.user_discription }}</span>
         </div>
       </div>
     </div>
@@ -50,7 +50,24 @@ export default {
   components: {
     Post
   },
-  async created(){
+  data() {
+    return {
+      currentUserFlag: false,
+      userProfile: {}
+    }
+  },
+  async created() {
+    const curretUser = this.$store.getters.current_user
+    let user_id = this.$route.params.id
+    user_id === curretUser.id ? this.currentUserFlag = true : this.currentUserFlag = false
+    if (this.currentUserFlag) {
+      this.userProfile = this.$store.getters.current_user
+    }
+    else {
+      this.axios.get(`/user/${user_id}`)
+        .then(res => this.userProfile = res.data)
+        .catch(error => this.$router.push) 
+    }
     await post_list_fetch()
   }
 }

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -3,6 +3,7 @@ import HomePage from "../components/pages/HomePage.vue";
 import LoginPage from "../components/pages/LoginPage.vue";
 import SignUpPage from "../components/pages/SignUpPage.vue";
 import SettingUserInfo from "../components/pages/SettingUserInfo.vue";
+import UserPage from "../components/pages/UserPage.vue";
 import NotFoundError from '../components/pages/error/NotFound.vue';
 import InternalServerError from '../components/pages/error/InternalServerError.vue';
 import silent_refresh  from '../../plugins/silent-refresh-token.js'
@@ -30,6 +31,11 @@ const routes = [
     path: "/setting/:id/",
     name: "UserSetting",
     component: SettingUserInfo
+  },
+  {
+    path: "/:id/",
+    name: "UserPage",
+    component: UserPage
   },
   {
     path: '/error',

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -35,7 +35,23 @@ const routes = [
   {
     path: "/:id/",
     name: "UserPage",
-    component: UserPage
+    component: UserPage,
+    beforeEnter: (to, from, next) => {
+      if (to.params.id === store.getters.current_user.id) {
+        next()
+        return
+      }
+      axios.get(`/user/${to.params.id}`)
+        .then(res => {
+          store.dispatch('getUserPageInfo', res.data)
+          next()
+        })
+        .catch(() => {
+          const message = 'ユーザーが見つかりません'
+          next({ path:'/home' })
+          store.dispatch('getToast', { message })
+        }) 
+    }
   },
   {
     path: '/error',

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -19,7 +19,8 @@ export const store = createStore({
       postFormModal: {
         isVisible: false
       },
-      postList: []
+      postList: [],
+      userPage: {}
     }
   },
   mutations: {
@@ -60,6 +61,9 @@ export const store = createStore({
           post.body = payload.body
         }
       })
+    },
+    updateUserPageInfo(state, payload) {
+      state.userPage = payload
     }
   },
   actions: {
@@ -97,6 +101,9 @@ export const store = createStore({
     },
     updatePost({ commit }, updatedPostContent) {
       commit('updatePost', updatedPostContent)
+    },
+    getUserPageInfo({ commit }, userInfomation) {
+      commit('updateUserPageInfo', userInfomation)
     }
   },
   getters: {
@@ -127,6 +134,9 @@ export const store = createStore({
         return (a.created_at > b.created_at) ? -1 : 1;  //オブジェクト昇順ソート
       })
       return postListByDate
+    },
+    userPage(state) {
+      return state.userPage
     }
   }
 })


### PR DESCRIPTION
## 概要
ユーザーの情報を表示するマイページを作成した
ユーザー名、アイコン、自己紹介、ユーザーごとの投稿(未実装)が参照できる
close #70 

## やったこと
* `/:user_id`に遷移することでそのユーザーごとのページが表示されるように実装
  *  ユーザー情報として名前とアイコン画像、自己紹介を表示している
  * ログインユーザーの場合はログイン時に取得している情報を参照している
  * ログインユーザーでない場合はuser_idをもとにAPIを叩き情報を取得し、表示している
* user_idが不正なものである場合は画面遷移は行われず、エラー表示用のトースターを出力する
* APIメソッドとしてuser_idから特定のユーザー情報を返すものを作成
  *  返す情報はid, name,image_url,user_discription

## 確認項目
- [x] user_idに基づき画面遷移が適切に行われるか
- [x] 画面遷移後の表示に崩れはないか
- [x] ログインユーザーとそれ以外のユーザーで表示が変わり、APIへ通信が削減できているか
- [x] ユーザーが見つからない場合、画面遷移が行われず、トースターを出力しているか

## その他
ユーザーごとのページに表示する投稿をそのユーザーが投稿したものだけを表示するように修正する必要がある。
またフォローのボタンが機能するように追加で機能を実装する　
relation #74 