### PR TITLE
フォロワーフォロー中ユーザーを表示し、フォローフォロー解除機能を作成

### DIFF
--- a/front/plugins/user-relationship-fetch.js
+++ b/front/plugins/user-relationship-fetch.js
@@ -1,0 +1,24 @@
+import axios from "axios";
+import router from '../src/router'
+import { store } from '../store/index.js'
+
+const user_relationship_fetch = async (to) => {
+  const user_id = to.params.id
+  // ログインユーザー出なければ情報を取得
+  if (user_id !== store.getters.current_user.id) {   
+    await axios.get(`/user/${user_id}`)
+    .then(res => {
+      store.dispatch('getUserPageInfo', res.data)
+    })
+    .catch(() => {
+      const message = 'ユーザーが見つかりません'
+      router.push('/home')
+      store.dispatch('getToast', { message })
+    })
+  }
+  // フォローフォロワーユーザーを取得
+  const fetchUserRelationshipsList = await axios.get(`/user/${user_id}/relationship_list`)
+  store.dispatch('getUserRelationshipsList', fetchUserRelationshipsList.data)
+}
+
+export default user_relationship_fetch

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -25,7 +25,8 @@
             <span v-if="!currentUserFlag" class="ml-6 px-6 py-2 cursor-pointer font-semibold rounded-full text-xs text-white bg-blue-400">フォロー</span>
           </div>
           <div class="flex mb-4">
-            <span class="mr-6 text-sm">フォロワー<span class="font-bold">10</span>人</span><span class="text-sm">フォロー中<span class="font-bold">10</span>人</span>
+            <span class="mr-6 text-sm">フォロワー<span class="font-bold">{{ UserRelationshipsList.followingUser.length }}</span>人</span>
+            <span class="text-sm">フォロー中<span class="font-bold">{{ UserRelationshipsList.followerUser.length }}</span>人</span>
           </div>
           <span class="w-full">{{ userProfile.user_discription }}</span>
         </div>
@@ -53,12 +54,29 @@ export default {
   data() {
     return {
       currentUserFlag: false,
-      userProfile: {}
+      userProfile: {},
+      UserRelationshipsList: {
+        followingUser: [],
+        followerUser: []
+      }
+    }
+  },
+  methods: {
+    async fetchUserRelationships(user_id) {
+      this.axios.get(`/user/${user_id}/relationship_list`)
+        .then(res => {
+          this.$store.dispatch('getUserRelationshipsList', res.data)
+          this.UserRelationshipsList.followingUser = this.$store.getters.followingUser
+          this.UserRelationshipsList.followerUser = this.$store.getters.followerUser
+        })
+        .catch(error => console.log(error))
+     
     }
   },
   async created() {
     const curretUser = this.$store.getters.current_user
     let user_id = this.$route.params.id
+    this.fetchUserRelationships(user_id)
     user_id === curretUser.id ? this.currentUserFlag = true : this.currentUserFlag = false
     if (this.currentUserFlag) {
       this.userProfile = this.$store.getters.current_user
@@ -67,7 +85,7 @@ export default {
       this.userProfile = this.$store.getters.userPage 
     }
     await post_list_fetch()
-  }
+  },
 }
 </script>
 

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    <div class="pt-12 pb-4 px-28">
+    <HeaderBar />
+    <div class="pt-28 pb-4 px-28">
       <div class="flex justify-start border-b border-solid border-gray-300 px-6 pb-4">
         <div class="px-14 py-6">
           <svg v-if="!userProfile.image_url" class="w-28 h-28 overflow-hidden rounded-full bg-gray-100 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
@@ -51,10 +52,12 @@
 
 <script>
 import Post from '../PostList/Post.vue'
+import HeaderBar from '../HeaderBar/HeaderBar.vue'
 import post_list_fetch from '../../../plugins/post-list-fetch.js'
 import user_relationship_fetch from '../../../plugins/user-relationship-fetch.js'
 export default {
   components: {
+    HeaderBar,
     Post
   },
   async beforeRouteEnter(to, from, next) {

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -35,24 +35,7 @@ const routes = [
   {
     path: "/:id/",
     name: "UserPage",
-    component: UserPage,
-    beforeEnter: (to, from, next) => {
-      const user_id = to.params.id
-      if (user_id === store.getters.current_user.id) {
-        next()
-        return
-      }
-      axios.get(`/user/${user_id}`)
-        .then(res => {
-          store.dispatch('getUserPageInfo', res.data)
-          next()
-        })
-        .catch(() => {
-          const message = 'ユーザーが見つかりません'
-          next({ path:'/home' })
-          store.dispatch('getToast', { message })
-        })
-    }
+    component: UserPage
   },
   {
     path: '/error',

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -37,11 +37,12 @@ const routes = [
     name: "UserPage",
     component: UserPage,
     beforeEnter: (to, from, next) => {
-      if (to.params.id === store.getters.current_user.id) {
+      const user_id = to.params.id
+      if (user_id === store.getters.current_user.id) {
         next()
         return
       }
-      axios.get(`/user/${to.params.id}`)
+      axios.get(`/user/${user_id}`)
         .then(res => {
           store.dispatch('getUserPageInfo', res.data)
           next()
@@ -50,7 +51,7 @@ const routes = [
           const message = 'ユーザーが見つかりません'
           next({ path:'/home' })
           store.dispatch('getToast', { message })
-        }) 
+        })
     }
   },
   {

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -20,7 +20,8 @@ export const store = createStore({
         isVisible: false
       },
       postList: [],
-      userPage: {}
+      userPage: {},
+      UserRelationshipsList: {}
     }
   },
   mutations: {
@@ -62,8 +63,12 @@ export const store = createStore({
         }
       })
     },
+  // マイページ関連
     updateUserPageInfo(state, payload) {
       state.userPage = payload
+    },
+    setRelationshipsList(state, payload) {
+      state.UserRelationshipsList = payload
     }
   },
   actions: {
@@ -102,8 +107,12 @@ export const store = createStore({
     updatePost({ commit }, updatedPostContent) {
       commit('updatePost', updatedPostContent)
     },
+  // マイページ関連
     getUserPageInfo({ commit }, userInfomation) {
       commit('updateUserPageInfo', userInfomation)
+    },
+    getUserRelationshipsList({ commit }, RelationshipsList) {
+      commit('setRelationshipsList', RelationshipsList)
     }
   },
   getters: {
@@ -135,8 +144,15 @@ export const store = createStore({
       })
       return postListByDate
     },
+  // マイページ関連
     userPage(state) {
       return state.userPage
-    }
+    },
+    followingUser(state) {
+      return state.UserRelationshipsList.following
+    },
+    followerUser(state) {
+      return state.UserRelationshipsList.follower
+    },
   }
 })


### PR DESCRIPTION
## 概要
マイページのフォロー中とフォロワーの人数を表示できるように修正
フォローボタンを押下時に相手をフォローでき、ボタンの表示を変更
フォロー中ボタンを押下時、フォロー解除ができるように実装した
close #74 
relation #70 
## やったこと
* フォローワーとフォロー中のユーザーを表示できるように修正
  *  APIを叩いて取得してきた配列の数を表示
  *  ユーザー情報とフォロワーフォロ中ユーザーの情報を取得してくる処理は別ファイルにまとめた
*  フォローができるように機能を追加
  *  フォローボタンを押すとフォローボタンのデザインがフォロー中となるように実装
  * フォローボタンを押して、フォローに成功するとフォローされたユーザーのフォロワーに自分が追加される
  * フォローに失敗した場合はトースターを表示
* フォロー解除機能を実装
  *  上記のようにフォローボタンがフォロー中になっている状態でボタンをクリックするとフォローを解除するかのダイヤログが出現し、はいを押すとフォローが解除される
  * フォローを解除するとユーザーのフォロワーから削除される
  * 失敗した際はトースターを出力する

## 確認項目
- [x] ユーザーのフォロワーフォロー中ユーザーが適切に表示されるか
- [x] フォロー機能が正常に動作するか
- [x] フォロー解除機能が正常に動作するか
- [x] フォローフォロー解除jに失敗した際にエラー用の表示がでるか
- [x] ユーザーページに遷移した際、APIへのリクエストにて正常にデータが表示、更新できているか

## その他



