### PR TITLE
# 80 マイページでは自分の投稿を表示するように修正

### DIFF
--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -18,15 +18,15 @@ class PostsController < ApplicationController
   end
 
   def index
-    post_all = Post.all
-    add_username_post_all = post_all.map do |post| 
-      posted_user = User.find_by(id: post[:user_id])
-      { 
-        "id" => post.id, "body" => post.body, "created_at" => post.created_at, "updated_at" => post.updated_at, 
-        "user_id" => post.user_id, "user_name" => posted_user.name, "image_icon" => posted_user.image_url
-      }
-    end
+    fetch_post = Post.all
+    add_username_post_all = fetch_post_list(fetch_post)
     render json: add_username_post_all
+  end
+
+  def individual_post
+    fetch_post = Post.where(user_id: params[:id])
+    individual_post = fetch_post_list(fetch_post)
+    render json: individual_post
   end
 
   def show
@@ -58,5 +58,15 @@ class PostsController < ApplicationController
   private
     def post_params
       params.require(:post).permit(:body, :user_id)
+    end
+
+    def fetch_post_list(fetch_post)
+      fetch_post.map do |post|
+        posted_user = User.find_by(id: post[:user_id])
+        {
+          "id" => post.id, "body" => post.body, "created_at" => post.created_at, "updated_at" => post.updated_at,
+          "user_id" => post.user_id, "user_name" => posted_user.name, "image_icon" => posted_user.image_url
+        }
+      end
     end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'posts/index'
   get 'posts/show'
   get 'posts/create'
+  get 'posts/individual_post/:id', to: 'posts#individual_post'
   resources :user, only:[:create, :index, :show, :edit, :update] do 
     member do
       get :relationship_list

--- a/front/plugins/post-list-fetch.js
+++ b/front/plugins/post-list-fetch.js
@@ -7,4 +7,10 @@ const post_list_fetch = async () => {
     .catch(error => console.log(error))
 }
 
-export default post_list_fetch
+const mypage_post_list_fetch = async () => {
+  await axios.get(`posts/individual_post/${store.getters.current_user.id}`)
+    .then(response => store.dispatch('getMyPostList', response.data)) 
+    .catch(error => console.log(error))
+}
+
+export { post_list_fetch, mypage_post_list_fetch }

--- a/front/src/components/PostForm/PostFormModal.vue
+++ b/front/src/components/PostForm/PostFormModal.vue
@@ -22,7 +22,8 @@
 </template>
 
 <script>
-import post_list_fetch from '../../../plugins/post-list-fetch.js'
+import { post_list_fetch } from '../../../plugins/post-list-fetch.js'
+import { mypage_post_list_fetch } from '../../../plugins/post-list-fetch.js'
 export default {
   data() {
     return {
@@ -43,6 +44,7 @@ export default {
         this.postContent.body = ''
         this.$emit("closeFormModal", false)  
         post_list_fetch()
+        mypage_post_list_fetch()
       },
       postContentError(error) {
         const message = error.response.data.message

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -59,7 +59,8 @@ import PostFavorite from './PostFavorite.vue'
 import PostDrawer from './PostDrawer.vue'
 import UpdatePostForm from '../PostForm/UpdatePostForm.vue'
 import Loading from '../Loading.vue'
-import post_list_fetch from '../../../plugins/post-list-fetch.js'
+import { post_list_fetch } from '../../../plugins/post-list-fetch.js'
+import { mypage_post_list_fetch } from '../../../plugins/post-list-fetch.js'
 export default {
   components: {
     PostUserinfo,
@@ -68,6 +69,11 @@ export default {
     PostDrawer,
     UpdatePostForm,
     Loading
+  },
+  props: {
+    page: {
+      type: String
+    }
   },
   data() {
     return {
@@ -94,7 +100,12 @@ export default {
   },
   computed: {
     showPostList() {
-      return this.$store.getters.postList
+      if (this.page === 'mypage') {
+        return this.$store.getters.mypostList
+      }
+      else {
+        return this.$store.getters.postList
+      }
     },
   },
   watch: {
@@ -113,7 +124,12 @@ export default {
     if (this.showPostList.length > 0) {
       this.isLoading = false
     }
-    await post_list_fetch()
+    if (this.page === 'mypage') {
+      await mypage_post_list_fetch()
+    }
+    else {
+      await post_list_fetch()
+    }
     this.isLoading = false
   },
   mounted() { 

--- a/front/src/components/pages/UserPage.vue
+++ b/front/src/components/pages/UserPage.vue
@@ -42,7 +42,7 @@
       <div class="container">
         <div class="flex justify-center">
           <div class="w-3/5 border border-gray-600 h-auto  border-t-0">
-            <Post />
+            <Post page="mypage"/>
           </div>
         </div>
       </div>
@@ -53,7 +53,6 @@
 <script>
 import Post from '../PostList/Post.vue'
 import HeaderBar from '../HeaderBar/HeaderBar.vue'
-import post_list_fetch from '../../../plugins/post-list-fetch.js'
 import user_relationship_fetch from '../../../plugins/user-relationship-fetch.js'
 export default {
   components: {
@@ -125,7 +124,6 @@ export default {
   },
   async created() {
     this.setUserRelationshipInfo()
-    await post_list_fetch()
   },
   watch: {
     // URLパラメータの変更を検知して反映させる

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -20,6 +20,7 @@ export const store = createStore({
         isVisible: false
       },
       postList: [],
+      mypostList: [],
       userPage: {},
       UserRelationshipsList: {}
     }
@@ -50,14 +51,26 @@ export const store = createStore({
     setPostList(state, payload) {
       state.postList = payload
     },
+    setMyPostList(state, payload) {
+      state.mypostList = payload
+    },
     deletePost(state, payload) {
       const deletedPostArray = state.postList.filter(post => {
         return post.id !== payload
       })
+      const deletedMypostArray = state.mypostList.filter(post => {
+        return post.id !== payload
+      })
       state.postList = deletedPostArray
+      state.mypostList = deletedMypostArray
     },
     updatePost(state, payload) {
       state.postList.map(post => {
+        if (post.id === payload.id) {
+          post.body = payload.body
+        }
+      })
+      state.mypostList.map(post => {
         if (post.id === payload.id) {
           post.body = payload.body
         }
@@ -101,6 +114,9 @@ export const store = createStore({
     getPostList({ commit }, postList) {
       commit('setPostList', postList)
     },
+    getMyPostList({ commit }, postList) {
+      commit('setMyPostList', postList)
+    },
     deletePost({ commit }, selectedPost) {
       commit('deletePost', selectedPost)
     },
@@ -143,6 +159,15 @@ export const store = createStore({
         return (a.created_at > b.created_at) ? -1 : 1;  //オブジェクト昇順ソート
       })
       return postListByDate
+    },
+    mypostList(state) {
+      let mypostListByDate =  Object.keys(state.mypostList).map(key => {
+        return state.mypostList[key];
+      })
+      mypostListByDate.sort(function (a, b) {
+        return (a.created_at > b.created_at) ? -1 : 1;
+      })
+      return mypostListByDate
     },
   // マイページ関連
     userPage(state) {


### PR DESCRIPTION
## 概要
mypageで表示している投稿は自分以外の投稿も含まれていたため自分の投稿だけを表示できるように修正した。

close #80 

## やったこと
- ユーザーIDを指定した場合にそのユーザーの投稿を返すAPIを作成
- 上記で作成したAPIを叩くための関数を別ファイルとして作成
- マイページ上での表示を修正
  -  マイページであれば自分だけの投稿を表示し、それ以外であれば他の投稿も表示

## 確認項目
- [x] マイページを表示した際、自分の投稿だけが表示されているか
- [x] 投稿時、再読み込み時にも自分の投稿だけが表示されるようになっているか
- [x] ホーム画面で表示されている投稿に影響がないか

## その他
とくになし