### PR TITLE
#82 いいね機能の実装

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include UserAuthenticateService
+  include UserSessionizeService
 
   private
   

--- a/api/app/controllers/favorites_controller.rb
+++ b/api/app/controllers/favorites_controller.rb
@@ -1,0 +1,21 @@
+class FavoritesController < ApplicationController
+  before_action :set_post
+  before_action :sessionize_user
+
+  def create
+    Favorite.create(user_id: session_user.id,  post_id: @post.id)
+    render status: 200
+  end
+
+  def destroy
+    favorite = Favorite.find_by(user_id: session_user.id, post_id: @post.id)
+    favorite.destroy
+    render status: 204
+  end
+
+  private
+
+  def set_post
+    @post = Post.find_by(id: params[:post_id])
+  end
+end

--- a/api/app/controllers/posts_controller.rb
+++ b/api/app/controllers/posts_controller.rb
@@ -30,7 +30,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    post_unique = Post.find(params[:id])
+    fetch_post = Post.find(params[:id])
     render json: post_unique
   end
 
@@ -63,9 +63,11 @@ class PostsController < ApplicationController
     def fetch_post_list(fetch_post)
       fetch_post.map do |post|
         posted_user = User.find_by(id: post[:user_id])
+        favorite_quantity = Favorite.select(:id,:user_id).where(post_id: post[:id])
         {
           "id" => post.id, "body" => post.body, "created_at" => post.created_at, "updated_at" => post.updated_at,
-          "user_id" => post.user_id, "user_name" => posted_user.name, "image_icon" => posted_user.image_url
+          "user_id" => post.user_id, "user_name" => posted_user.name, "image_icon" => posted_user.image_url,
+          "favorite" => favorite_quantity
         }
       end
     end

--- a/api/app/models/favorite.rb
+++ b/api/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates_uniqueness_of :post_id, scope: :user_id
+end

--- a/api/app/models/post.rb
+++ b/api/app/models/post.rb
@@ -1,6 +1,8 @@
 class Post < ApplicationRecord
   # アソシエーション
   belongs_to :user
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_users, through: :favorites, source: :user
   
   before_create :set_post_uuid
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :followed, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :following_user, through: :follower, source: :followed # 自分がフォローしている人
   has_many :follower_user, through: :followed, source: :follower # 自分をフォローしている人
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_posts, through: :favorites, source: :post
   has_secure_password
   has_one_attached :image_icon # Active Recordによる疑似カラム生成
   attr_accessor :image

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
-  get 'posts/new'
-  get 'posts/index'
-  get 'posts/show'
-  get 'posts/create'
+  resources :posts do
+    resource :favorites, only: [:create, :destroy]
+  end
   get 'posts/individual_post/:id', to: 'posts#individual_post'
+  
   resources :user, only:[:create, :index, :show, :edit, :update] do 
     member do
       get :relationship_list

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_11_021550) do
+ActiveRecord::Schema.define(version: 2023_02_24_031201) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2022_12_11_021550) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_favorites_on_post_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -61,6 +70,8 @@ ActiveRecord::Schema.define(version: 2022_12_11_021550) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "favorites", "posts"
+  add_foreign_key "favorites", "users"
   add_foreign_key "relationships", "users", column: "followed_id"
   add_foreign_key "relationships", "users", column: "follower_id"
 end

--- a/front/src/components/PostList/Post.vue
+++ b/front/src/components/PostList/Post.vue
@@ -37,7 +37,10 @@
         <div class="w-full">
           <div class="flex justify-end items-center">
             <PostReply />
-            <PostFavorite />
+            <PostFavorite 
+            :post_id="post.id" 
+            :favorite_quantity="post.favorite"
+            />
           </div>
         </div>
       </div>  

--- a/front/src/components/PostList/PostFavorite.vue
+++ b/front/src/components/PostList/PostFavorite.vue
@@ -1,13 +1,62 @@
 <template>
-  <div class="text-center py-2 m-2">
-    <a href="#" class="w-12 mt-1 group flex items-center text-gray-500 px-3 py-2 text-base leading-6 font-medium rounded-full hover:bg-blue-800 hover:text-blue-300">
-      <svg class="text-center h-7 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24"><path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path></svg>
-    </a>
+  <div class="text-center py-2 m-2 flex align-middle">
+    <span class="m-auto text-sm text-gray-500 pt-2">{{ favoriteAll }}</span>
+    <span @click="pressFavorite" class="w-12 mt-1 group flex items-center cursor-pointer text-gray-500 pr-3 pl-1 text-base leading-6 font-medium rounded-full hover:text-red-500 duration-150">
+      <svg 
+      fill="none"
+      :class="{ 'fill-red-600': favoriteExists === true, 'stroke-red-600': favoriteExists === true}" 
+      class="text-center h-7 w-6" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" stroke="currentColor" viewBox="0 0 24 24">
+      <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path></svg>
+    </span>
   </div>
 </template>
 
 <script>
 export default {
-  
+  props: {
+    post_id: {
+      type: Number
+    },
+    favorite_quantity: {
+      type: Array
+    },
+  },
+  methods: {
+    pressFavorite() {
+      // いいねが押されている場合と押されていない場合
+      if (this.favoriteExists) {
+        this.deleteFavorite()
+      } else {
+        this.createFavorite()
+      }
+    },
+    createFavorite() {
+      this.axios.post(`/posts/${this.post_id}/favorites`)
+        .then(
+          this.favorite_quantity.push({user_id: this.$store.getters.current_user.id })
+        ) 
+    },
+    deleteFavorite() {
+      this.axios.delete(`/posts/${this.post_id}/favorites`)
+        .then(() => {
+          let deleteIndex
+          this.favorite_quantity.forEach((value, key) => {
+            if (value.user_id === this.$store.getters.current_user.id) {
+              deleteIndex = key              
+            }
+          })
+          this.favorite_quantity.splice(deleteIndex, 1)
+        }) 
+    }
+  },
+  computed: {
+    favoriteAll() {
+      return this.favorite_quantity.length
+    },
+    favoriteExists() {
+      const done_favorite_judge = this.favorite_quantity.some(favorite => favorite.user_id === this.$store.getters.current_user.id)
+      return done_favorite_judge
+    }
+  }
 }
 </script>


### PR DESCRIPTION
## 概要
各投稿にいいねを押せるように機能を追加  
投稿下部のイイネボタンを押すことでいいねをつけることができる

close #82 

## やったこと
- FavoriteAPIを作成
   -  いいねを作成・削除することができる
   　- Favoriteテーブルに情報を追加・削除ができる
- Favorite テーブルを作成
  - UserテーブルとPostテーブルの中間テーブル
  - いいねを登録することができる
- いいねを押したときにFavoriteAPIと連携し、DBにデータを保存できるようにした
- いいねを押したときボタンの色を変化させる
  - 既にいいねが押されている場合は変化している状態
  - いいねを押している状態でもう一度いいねボタンを押すといいねが取り消される。
- 投稿についているいいねの総数を表示

## 確認項目
- [x] いいねボタンを押した際にDBに情報が反映されているか
- [x] いいねボタンを押したときにボタンの表示が切り替えできているか
- [x] いいねボタンを押した際にいいねの総数が変化しているか
- [x] いいねの総数が期待通り表示されているか
- [x] マイページの投稿一覧でもいいねが反映されているか

## その他