### PR TITLE
production環境でS3を利用できるように設定

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -40,5 +40,10 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :production do
+  # S3
+  gem "aws-sdk-s3", require: false
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # ActiveStorage 
   Rails.application.routes.default_url_options[:host] = 'api.workout-share.com'
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/api/config/storage.yml
+++ b/api/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
+amazon:
+  service: S3
+  access_key_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>
+  region:  <%= ENV['S3_USED_RESION'] %>
+  bucket:  <%= ENV['S3_USED_BUCKET'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要
production環境においてRailsのActiveStorageの画像保存先としてS3を利用できるように設定した
close #87 

### やったこと
- Production環境にのみ"aws-sdk-s3"を追加
- ActiveStorageのStorage設定を編集
- AWS側でAPIコンテナのタスクに環境変数を追加


### スクリーンショット
![スクリーンショット 2023-05-02 17 14 23](https://user-images.githubusercontent.com/76101803/235614554-47ced445-828f-462b-933a-80fca1d980e4.png)