### PR TITLE
GithubActionsを使用しCDを追加

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -66,11 +66,19 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+    - name: Download front task definition
+      run: |
+        aws ecs describe-task-definition --task-definition $ECS_TASK_DEFINITION_FRONT --query taskDefinition > front-task-definition.json
+
+    - name: Download backend task definition
+      run: |
+        aws ecs describe-task-definition --task-definition $ECS_TASK_DEFINITION_BACKEND --query taskDefinition > backend-task-definition.json
+
     - name: Fill in the new frontend image ID in the Amazon ECS task definition
       id: task-def-front
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition: ${{ env.ECS_TASK_DEFINITION_FRONT }}
+        task-definition: front-task-definition.json
         container-name: ${{ env.CONTAINER_NAME_FRONT }}
         image: ${{ steps.build-image-front.outputs.image }}
     
@@ -78,7 +86,7 @@ jobs:
       id: task-def-backend
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition: ${{ env.ECS_TASK_DEFINITION_BACKEND }}
+        task-definition: backend-task-definition.json
         container-name: ${{ env.CONTAINER_NAME_BACKEND }}
         image: ${{ steps.build-image-backend.outputs.image }}
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -3,19 +3,20 @@ name: Deploy to Amazon ECS
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
 
 env:
-  AWS_REGION: MY_AWS_REGION
-  ECR_REPOSITORY_FRONT: MY_ECR_REPOSITORY_FRONT
-  ECR_REPOSITORY_BACKEND: MY_ECR_REPOSITORY_BACKEND
-  ECS_SERVICE_FRONT: MY_ECS_SERVICE_FRONT
-  ECS_SERVICE_BACKEND: MY_ECS_SERVICE_BAKCEND
-  ECS_CLUSTER: MY_ECS_CLUSTER
-  ECS_TASK_DEFINITION_FRONT: MY_ECS_TASK_DEFINITION_FRONT     
-  ECS_TASK_DEFINITION_BACKEND: MY_ECS_TASK_DEFINITION_BACKEND
-  CONTAINER_NAME_FRONT: MY_CONTAINER_NAME_FRONT
-  CONTAINER_NAME_BACKEND: MY_CONTAINER_NAME　_BACKEND
+  AWS_REGION: ${{ vars.MY_AWS_REGION }}
+  ECR_REGISTRY: ${{ vars.MY_ECR_REGISTRY }}
+  ECR_REPOSITORY_FRONT: ${{ vars.MY_ECR_REPOSITORY_FRONT }}
+  ECR_REPOSITORY_BACKEND: ${{ vars.MY_ECR_REPOSITORY_BACKEND }}
+  ECS_SERVICE_FRONT: ${{ vars.MY_ECS_SERVICE_FRONT }}
+  ECS_SERVICE_BACKEND: ${{ vars.MY_ECS_SERVICE_BACKEND }}
+  ECS_CLUSTER: ${{ vars.MY_ECS_CLUSTER }}
+  ECS_TASK_DEFINITION_FRONT: ${{ vars.MY_ECS_TASK_DEFINITION_FRONT }}
+  ECS_TASK_DEFINITION_BACKEND: ${{ vars.MY_ECS_TASK_DEFINITION_BACKEND }}
+  CONTAINER_NAME_FRONT: ${{ vars.MY_CONTAINER_NAME_FRONT }}
+  CONTAINER_NAME_BACKEND: ${{ vars.MY_CONTAINER_NAME_BACKEND }}
 
 permissions:
   contents: read
@@ -41,25 +42,27 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build, tag, and push　　frontend image to Amazon ECR
+    - name: Build, tag, and push frontend image to Amazon ECR
       id: build-image-front
       env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: MY_ECR_REPOSITORY_FRONT
+        ECR_REGISTRY: ${{ env.ECR_REGISTRY }}
+        ECR_REPOSITORY: ${{ env.ECR_REPOSITORY_FRONT }}
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY 
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f front/Dockerfile.prod front/
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
     
     - name: Build, tag, and push backend image to Amazon ECR
       id: build-image-backend
       env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: MY_ECR_REPOSITORY_BACKEND 
+        ECR_REGISTRY: ${{ env.ECR_REGISTRY }}
+        ECR_REPOSITORY: ${{ env.ECR_REPOSITORY_BACKEND }}
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY 
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f api/Dockerfile.prod api/
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -3,7 +3,7 @@ name: Deploy to Amazon ECS
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "main" ]
 
 env:
   AWS_REGION: ${{ vars.MY_AWS_REGION }}

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,96 @@
+
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  AWS_REGION: MY_AWS_REGION
+  ECR_REPOSITORY_FRONT: MY_ECR_REPOSITORY_FRONT
+  ECR_REPOSITORY_BACKEND: MY_ECR_REPOSITORY_BACKEND
+  ECS_SERVICE_FRONT: MY_ECS_SERVICE_FRONT
+  ECS_SERVICE_BACKEND: MY_ECS_SERVICE_BAKCEND
+  ECS_CLUSTER: MY_ECS_CLUSTER
+  ECS_TASK_DEFINITION_FRONT: MY_ECS_TASK_DEFINITION_FRONT     
+  ECS_TASK_DEFINITION_BACKEND: MY_ECS_TASK_DEFINITION_BACKEND
+  CONTAINER_NAME_FRONT: MY_CONTAINER_NAME_FRONT
+  CONTAINER_NAME_BACKEND: MY_CONTAINER_NAME　_BACKEND
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push　　frontend image to Amazon ECR
+      id: build-image-front
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: MY_ECR_REPOSITORY_FRONT
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+    
+    - name: Build, tag, and push backend image to Amazon ECR
+      id: build-image-backend
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: MY_ECR_REPOSITORY_BACKEND 
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Fill in the new frontend image ID in the Amazon ECS task definition
+      id: task-def-front
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ env.ECS_TASK_DEFINITION_FRONT }}
+        container-name: ${{ env.CONTAINER_NAME_FRONT }}
+        image: ${{ steps.build-image-front.outputs.image }}
+    
+    - name: Fill in the new backend image ID in the Amazon ECS task definition
+      id: task-def-backend
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ env.ECS_TASK_DEFINITION_BACKEND }}
+        container-name: ${{ env.CONTAINER_NAME_BACKEND }}
+        image: ${{ steps.build-image-backend.outputs.image }}
+
+    - name: Deploy Amazon ECS frontend task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-front.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE_FRONT }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true
+        
+    - name: Deploy Amazon ECS backend task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-backend.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE_BACKEND }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true

--- a/front/Dockerfile.prod
+++ b/front/Dockerfile.prod
@@ -7,7 +7,7 @@ ENV TZ Asia/Tokyo
 COPY package.json ./
 COPY package-lock.json ./
 
-RUN apk update && npm install -g
+RUN apk update && npm install -g && npm update
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## 概要
Github Actionsを用いて、mainブランチにpush後(devからmainへマージ後)
AWSのECSへ自動デプロイが行えるようにCDを実装しました。

closed #94

### やったこと
- githubActionsを利用するためディレクトリを作成、ファイルを配置
- スクリプト内で使用するSecretや変数などを設定
- ECSへの自動デプロイできるスクリプトを作成
1. AWSのCredentials情報を登録
2. AWSへログイン
3. フロントエンドとバックエンドの各コンテナのイメージを作成し、ECRへPush
4. 既にAWS側で作成済みのタスク定義ファイルをダウンロード
5. ダウンロードしたタスク定義ファイルを元にタスク定義を作成
6. フロントエンドとバックエンドのサービス内でタスクを実行


## その他
今後はCIを追加する(テストとか)